### PR TITLE
Added SelectRWSensor and priority_mode

### DIFF
--- a/hass-addon-sunsynk-dev/CHANGELOG.md
+++ b/hass-addon-sunsynk-dev/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## **2022.08.01-0.2.2** - 2022-08-01
+
+- Python sunsynk module 0.2.2:
+
+  - Introduced SelectRWSensor - [#37](https://github.com/kellerza/sunsynk/issues/37)
+  - Added "priority_mode" writable sensor allowing switching between battery and load priorities
+  - NumberRWSensor now supports factor and validates min/max
+
+- Sunsynk Dev Add-On
+  - Use Home Assistant MQTT Select integration when encountering SelectRWSensor
+  - The "priority_mode" sensor is now available as a Select entity
 
 ## **2022.07.24-0.2.1** - 2022-07-24
 

--- a/hass-addon-sunsynk-dev/Dockerfile
+++ b/hass-addon-sunsynk-dev/Dockerfile
@@ -8,7 +8,7 @@ FROM ${BUILD_FROM}
 #     python3-pip \
 #   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.1
+RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/hass-addon-sunsynk-dev/config.yaml
+++ b/hass-addon-sunsynk-dev/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk Inverter Add-on (dev)
-version: 2022.07.24-0.2.1
+version: 2022.08.01-0.2.2
 slug: hass-addon-sunsynk-dev
 description: Add-on for the Sunsynk Inverter
 startup: services

--- a/hass-addon-sunsynk-dev/filter.py
+++ b/hass-addon-sunsynk-dev/filter.py
@@ -197,6 +197,7 @@ def suggested_filter(sensor: Sensor) -> str:
         "fault": "round_robin",
         "grid_connected_status": "last",
         "overall_state": "step",
+        "priority_mode": "round_robin",
         "sd_status": "step",
         "serial": "round_robin",
     }

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -106,6 +106,7 @@ async def hass_discover_sensors(serial: str, rated_power: float) -> None:
                     on_change=create_on_change_handler(filt, str),
                 )
             )
+            continue
 
         ents.append(
             SensorEntity(

--- a/sunsynk/__init__.py
+++ b/sunsynk/__init__.py
@@ -4,4 +4,4 @@
 from .sensor import Sensor, group_sensors, update_sensors
 from .sunsynk import Sunsynk
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -8,6 +8,7 @@ from sunsynk.sensor import (
     NumberRWSensor,
     RWSensor,
     SDStatusSensor,
+    SelectRWSensor,
     Sensor,
     SerialSensor,
     TempSensor,
@@ -161,6 +162,9 @@ _SENSORS += (BATTERY_SHUTDOWN_CAPACITY, BATTERY_RESTART_CAPACITY, BATTERY_LOW_CA
 #################
 # System program
 #################
+_SENSORS.append(
+    SelectRWSensor(243, "Priority Mode", options={0: "Battery first", 1: "Load first"})
+)
 PROGRAM = (
     TimeRWSensor(250, "Prog1 Time"),
     TimeRWSensor(251, "Prog2 Time"),

--- a/sunsynk/sensor.py
+++ b/sunsynk/sensor.py
@@ -249,6 +249,10 @@ class TimeRWSensor(RWSensor):
         sval = str(self.reg_value[0])
         self.value = f"{sval[:-2]}:{sval[-2:]}"
 
+    def value_to_reg(self, value: Any) -> int | Tuple[int, ...]:
+        """Get the reg value from a display value."""
+        raise NotImplementedError()
+
 
 class SDStatusSensor(Sensor):
     """SD card status."""

--- a/tests/sunsynk/test_sensor.py
+++ b/tests/sunsynk/test_sensor.py
@@ -12,6 +12,7 @@ from sunsynk.sensor import (
     MathSensor,
     NumberRWSensor,
     SDStatusSensor,
+    SelectRWSensor,
     Sensor,
     SerialSensor,
     TempSensor,
@@ -147,7 +148,7 @@ def test_math() -> None:
         MathSensor((0, 1), "", "")
 
 
-def test_numberrw() -> None:
+def test_number_rw() -> None:
     s = NumberRWSensor(1, "", min=1, max=10)
 
     deps = s.dependencies()
@@ -174,6 +175,35 @@ def test_numberrw() -> None:
     assert s.max_value == 0
     s.max.value = 30
     assert s.max_value == 30
+
+    assert s.update_reg_value(25)
+    assert s.reg_value == (25,)
+
+    assert s.update_reg_value(500) is False
+    assert s.update_reg_value(-1) is False
+    assert s.reg_value == (25,)
+
+    s = NumberRWSensor(1, "", factor=0.1)
+    s.reg_to_value(485)
+    assert s.value == 48.5
+    s.update_reg_value(50)
+    assert s.reg_value == (500,)
+
+
+def test_select_rw() -> None:
+    s = SelectRWSensor(1, "", options={1: "one", 2: "two"})
+    s.reg_to_value(1)
+
+    assert s.value == "one"
+    assert s.available_values() == ["one", "two"]
+    assert s.update_reg_value("two")
+    assert s.reg_value == (2,)
+
+    assert s.update_reg_value("five") is False
+    assert s.reg_value == (2,)
+
+    s.reg_to_value(5)
+    assert s.value == "Unknown 5"
 
 
 def test_update_func() -> None:


### PR DESCRIPTION
This is the second PR addressing #37.

A `SelectRWSensor` has been introduced which supports an `options` dictionary of register value to display value pairs. This sensor is then used by the dev add-on to create a Home Assistant [MQTT Select](https://www.home-assistant.io/integrations/select.mqtt/).

`RWSensor` also gained come common writable sensor functionality through the `update_reg_value` method which has the common steps to update the register value of the sensor. Subclasses merely need to map an incoming `value` to a register value. Any of these methods can be renamed if needed.

`NumberRWSensor` was also enhanced to deal with `factor` and to validate the incoming `value` against `min_value` and `max_value` when creating a register value.