### PR TITLE
Update HASS auto discovery info when sensor values change & add RWSensor icons

### DIFF
--- a/hass-addon-sunsynk-dev/CHANGELOG.md
+++ b/hass-addon-sunsynk-dev/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+
+## **2022.08.27-0.2.4** - 2022-08-27
+
+- Python sunsynk module 0.2.4:
+
+  - Added on_change callback on Sensor class allowing for reacting to value changes
+  - Changed battery shutdown, restart and low capacity sensors to be instances of RWSensor in prepraration for them to become writable and to distinguish them from the battery SOC sensors
+
+- Sunsynk Dev Add-On
+
+  - Update HASS discovery info for a sensor's dependants when its value changes
+  - Automatically add sensor dependencies, if not specified in OPTS, as hidden sensors
+  - HASS device_class is no longer set for RWSensor entities
+  - Added icons for RWSensor entities
+
 ## **2022.08.21-0.2.3** - 2022-08-21
 
 - Python sunsynk module 0.2.3:

--- a/hass-addon-sunsynk-dev/Dockerfile
+++ b/hass-addon-sunsynk-dev/Dockerfile
@@ -8,7 +8,7 @@ FROM ${BUILD_FROM}
 #     python3-pip \
 #   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.3
+RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.4
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/hass-addon-sunsynk-dev/config.yaml
+++ b/hass-addon-sunsynk-dev/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk Inverter Add-on (dev)
-version: 2022.08.21-0.2.3
+version: 2022.08.27-0.2.4
 slug: hass-addon-sunsynk-dev
 description: Add-on for the Sunsynk Inverter
 startup: services

--- a/hass-addon-sunsynk-dev/mqtt.py
+++ b/hass-addon-sunsynk-dev/mqtt.py
@@ -63,14 +63,12 @@ class Entity:
     expire_after: int = attr.field(default=0)  # unavailable if not updated
     enabled_by_default: bool = attr.field(default=True)
     entity_category: str = attr.field(default="")
+    icon: str = attr.field(default="")
 
     _path = ""
 
     def __attrs_post_init__(self) -> None:
         """Init the class."""
-        if not self.device_class:
-            # Try device_class from unit_of_measurement
-            self.device_class = hass_device_class(unit=self.unit_of_measurement)
         if not self.state_class and self.device_class == "energy":
             self.state_class = "total_increasing"
 
@@ -140,12 +138,6 @@ class NumberEntity(Entity):
     on_change: Callable = attr.field(default=None)
 
     _path = "number"
-
-    def __attrs_post_init__(self) -> None:
-        """Init the class."""
-        # Override device_class to None
-        # https://github.com/home-assistant/core/issues/74533
-        self.device_class = None
 
 
 class MQTTClient:
@@ -337,6 +329,16 @@ def hass_device_class(*, unit: str) -> str:
         "A": "current",
         "°C": "temperature",
         "%": "battery",
+    }.get(unit, "")
+
+
+def hass_default_rw_icon(*, unit: str) -> str:
+    """Get the HASS default icon from the unit."""
+    return {
+        "W": "mdi:flash",
+        "V": "mdi:sine-wave",
+        "A": "mdi:current-ac",
+        "%": "mdi:battery-lock",
     }.get(unit, "")
 
 

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -70,7 +70,6 @@ async def hass_discover_sensors(serial: str, rated_power: float) -> None:
         model=f"{int(rated_power/1000)}kW Inverter {serial}",
         manufacturer="Sunsynk",
     )
-    # pylint: disable=import-outside-toplevel
     global DEVICE  # pylint: disable=global-statement
     DEVICE = dev
 
@@ -134,14 +133,10 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
         }
 
         if isinstance(sensor, RWSensor):
-            ent.update(
-                {
-                    "entity_category": "config",
-                    "icon": hass_default_rw_icon(unit=sensor.unit),
-                }
-            )
+            ent["entity_category"] = "config"
+            ent["icon"] = hass_default_rw_icon(unit=sensor.unit)
         else:
-            ent.update({"device_class": hass_device_class(unit=sensor.unit)})
+            ent["device_class"] = hass_device_class(unit=sensor.unit)
 
         if isinstance(sensor, NumberRWSensor):
             ents.append(
@@ -167,7 +162,7 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
             continue
 
         if isinstance(sensor, TimeRWSensor):
-            ent.update({"icon": "mdi:clock"})
+            ent["icon"] = "mdi:clock"
             ents.append(
                 SelectEntity(
                     **ent,

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -12,7 +12,16 @@ from typing import Any, Callable, Dict, List, Sequence, Tuple
 
 import yaml
 from filter import RROBIN, Filter, getfilter, suggested_filter
-from mqtt import MQTT, Device, Entity, NumberEntity, SelectEntity, SensorEntity
+from mqtt import (
+    MQTT,
+    Device,
+    Entity,
+    NumberEntity,
+    SelectEntity,
+    SensorEntity,
+    hass_default_rw_icon,
+    hass_device_class,
+)
 from options import OPT, SS_TOPIC
 from profiles import profile_add_entities, profile_poll
 
@@ -115,12 +124,21 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
 
         ent = {
             "device": dev,
-            "entity_category": "config" if isinstance(sensor, RWSensor) else "",
             "name": f"{OPT.sensor_prefix} {sensor.name}".strip(),
             "state_topic": state_topic,
             "unique_id": f"{OPT.sunsynk_id}_{sensor.id}",
             "unit_of_measurement": sensor.unit,
         }
+
+        if isinstance(sensor, RWSensor):
+            ent.update(
+                {
+                    "entity_category": "config",
+                    "icon": hass_default_rw_icon(unit=sensor.unit),
+                }
+            )
+        else:
+            ent.update({"device_class": hass_device_class(unit=sensor.unit)})
 
         if isinstance(sensor, NumberRWSensor):
             ents.append(
@@ -146,6 +164,7 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
             continue
 
         if isinstance(sensor, TimeRWSensor):
+            ent.update({"icon": "mdi:clock"})
             ents.append(
                 SelectEntity(
                     **ent,

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -213,7 +213,7 @@ def startup() -> None:
 def setup_sensors() -> None:
     """Setup the sensors."""
     sens = {}
-    sens_dependencies: Dict[str, List[Sensor]] = defaultdict(list)
+    sens_dependants: Dict[str, List[Sensor]] = defaultdict(list)
     startup_sens = {SERIAL.id, RATED_POWER.id}
     filters: Dict[str, Filter] = {}
 
@@ -256,9 +256,9 @@ def setup_sensors() -> None:
 
         if isinstance(sen, (NumberRWSensor, TimeRWSensor)):
             for dep in sen.dependencies():
-                sens_dependencies[dep.id].append(sen)
+                sens_dependants[dep.id].append(sen)
 
-    for sen_id, deps in sens_dependencies.items():
+    for sen_id, deps in sens_dependants.items():
         try:
             sen = ALL_SENSORS.get(sen_id)
         except KeyError as err:

--- a/sunsynk/__init__.py
+++ b/sunsynk/__init__.py
@@ -4,4 +4,4 @@
 from .sensor import Sensor, group_sensors, update_sensors
 from .sunsynk import Sunsynk
 
-VERSION = "0.2.3"
+VERSION = "0.2.4"

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -154,9 +154,9 @@ _SENSORS += (
     Sensor(603, "Bat1 SOC", "%"),
     Sensor(611, "Bat1 Cycle"),
 )
-BATTERY_SHUTDOWN_CAPACITY = Sensor(217, "Battery Shutdown Capacity", "%")
-BATTERY_RESTART_CAPACITY = Sensor(218, "Battery Restart Capacity", "%")
-BATTERY_LOW_CAPACITY = Sensor(219, "Battery Low Capacity", "%")
+BATTERY_SHUTDOWN_CAPACITY = RWSensor(217, "Battery Shutdown Capacity", "%")
+BATTERY_RESTART_CAPACITY = RWSensor(218, "Battery Restart Capacity", "%")
+BATTERY_LOW_CAPACITY = RWSensor(219, "Battery Low Capacity", "%")
 _SENSORS += (BATTERY_SHUTDOWN_CAPACITY, BATTERY_RESTART_CAPACITY, BATTERY_LOW_CAPACITY)
 
 #################

--- a/sunsynk/sensor.py
+++ b/sunsynk/sensor.py
@@ -49,7 +49,7 @@ class Sensor:
     # ] = attr.field(default=None)
     reg_value: Tuple[int, ...] = attr.field(init=False, factory=tuple)
     on_change: Callable = attr.field(default=None)
-    __value: Union[float, int, str, None] = None
+    _value: Union[float, int, str, None] = None
 
     def append_to(self, arr: List[Sensor]) -> Sensor:
         """Append to a list of sensors."""
@@ -84,12 +84,12 @@ class Sensor:
     @property
     def value(self) -> Union[float, int, str, None]:
         """Get the current value."""
-        return self.__value
+        return self._value
 
     @value.setter
     def value(self, val: Union[float, int, str, None]) -> None:
-        old_value = self.__value
-        self.__value = val
+        old_value = self._value
+        self._value = val
         if old_value != val and self.on_change:
             self.on_change()
 

--- a/sunsynk/sensor.py
+++ b/sunsynk/sensor.py
@@ -38,6 +38,8 @@ def _signed(val: Union[int, float]) -> Union[int, float]:
 class Sensor:
     """Sunsynk sensor."""
 
+    # pylint: disable=too-many-instance-attributes
+
     reg_address: Tuple[int, ...] = attr.field(converter=ensure_tuple)
     name: str = attr.field()
     unit: str = attr.field(default="")

--- a/tests/hass-addon-sunsynk-dev/test_mqtt.py
+++ b/tests/hass-addon-sunsynk-dev/test_mqtt.py
@@ -37,6 +37,7 @@ def opt():
 def test_mqtt(mqtt):
     """Test MQTT."""
     assert mqtt.hass_device_class(unit="kWh") == "energy"
+    assert mqtt.hass_default_rw_icon(unit="W") == "mdi:flash"
 
 
 def test_mqtt_entity(mqtt):

--- a/tests/sunsynk/test_sensor.py
+++ b/tests/sunsynk/test_sensor.py
@@ -1,6 +1,7 @@
 """Sunsynk sensor tests."""
 import logging
 from typing import Sequence
+from unittest.mock import Mock
 
 import pytest
 
@@ -325,3 +326,16 @@ def test_dep() -> None:
 
     ctl = ALL_SENSORS["grid_ct_power"]
     assert ctl.id not in DEPRECATED
+
+
+def test_on_changed() -> None:
+    s = Sensor(1, "", "")
+    handler = Mock()
+    s.on_change = handler
+
+    s.value = 5
+    handler.assert_called_once()
+
+    handler.reset_mock()
+    s.reg_to_value(10)
+    handler.assert_called_once()

--- a/tests/sunsynk/test_sensor.py
+++ b/tests/sunsynk/test_sensor.py
@@ -339,3 +339,7 @@ def test_on_changed() -> None:
     handler.reset_mock()
     s.reg_to_value(10)
     handler.assert_called_once()
+
+    handler.reset_mock()
+    s.reg_to_value(10)
+    handler.assert_not_called()


### PR DESCRIPTION
This PR builds on the work done in #37 to allow for updating of HASS auto discovery info if a sensor, upon which other sensors depend for their min/max values, changes.

The changes here solve for two issues:

1. If the user of the add-on has added a sensor which depends on another sensor for the min/max values but the user has not added the latter sensor, it automatically gets added as a hidden sensor so that its value can be read in the main loop and the former sensor's HASS discovery info can be updated.
2. If the user walks over to the inverter and changes the sensor value, or the value is changed via the Home Assistant UI (if the sensor is a subclass of `RWSensor`), the change is picked up by the add-on and the HASS discovery info is updated.

Furthermore, the writable battery capacity sensors are now instances of RWSensor to distinguish them from the battery SOC sensors to fix an issue where the Home Assistant would pick the first (wrong) sensor with a device class of `battery` as the device's SOC.

Finally, some icons for RWSensor entities were added.