### PR TITLE
More writable sensors

### DIFF
--- a/hass-addon-sunsynk-dev/CHANGELOG.md
+++ b/hass-addon-sunsynk-dev/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## **2022.08.29-0.2.5** - 2022-08-29
+
+- Python sunsynk module 0.2.5:
+
+  - Introduced new _Battery Shutdown voltage_, _Battery Restart voltage_ and _Battery Low Voltage_ sensors
+  - Introduced new _Float voltage_ sensor upon which the _Prog1-6 Voltage_ sensors depend
+  - Made _Prog1-6 Charge_ and _Prog1-6 Voltage_ sensors writable
+  - Made _Equalization voltage_ and _Absorption voltage_ writable
+  - Made _Battery Shutdown Capacity_, _Battery Restart Capacity_ and _Battery Low Capacity_ writable
+  - Corrected _Prog1-6 Voltage_ factor to be 0.01
+
+- Sunsynk Dev Add-On
+
+  - For NumberEntity, use a step value to 0.1 if the factor of the sensor is less than 1
+
 ## **2022.08.27-0.2.4** - 2022-08-27
 
 - Python sunsynk module 0.2.4:
@@ -55,6 +70,7 @@
   - Deprecate Time x Power sensors in favour of Energy - [#27](https://github.com/kellerza/sunsynk/issues/27)
 
 - Sunsynk Add-On
+
   - Fix RR filter
 
 - Sunsynk Dev Add-On

--- a/hass-addon-sunsynk-dev/CHANGELOG.md
+++ b/hass-addon-sunsynk-dev/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## **2022.08.29-0.2.5** - 2022-08-29
+## **2022.08.30-0.2.5** - 2022-08-30
 
 - Python sunsynk module 0.2.5:
 
   - Introduced new _Battery Shutdown voltage_, _Battery Restart voltage_ and _Battery Low Voltage_ sensors
-  - Introduced new _Float voltage_ sensor upon which the _Prog1-6 Voltage_ sensors depend
+  - Introduced new _Battery Float voltage_ sensor upon which the _Prog1-6 Voltage_ sensors depend
   - Made _Prog1-6 Charge_ and _Prog1-6 Voltage_ sensors writable
-  - Made _Equalization voltage_ and _Absorption voltage_ writable
+  - Made _Equalization voltage_ and _Absorption voltage_ writable and renamed them to have a _Battery_ prefix
   - Made _Battery Shutdown Capacity_, _Battery Restart Capacity_ and _Battery Low Capacity_ writable
   - Corrected _Prog1-6 Voltage_ factor to be 0.01
 

--- a/hass-addon-sunsynk-dev/Dockerfile
+++ b/hass-addon-sunsynk-dev/Dockerfile
@@ -8,7 +8,7 @@ FROM ${BUILD_FROM}
 #     python3-pip \
 #   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.4
+RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.5
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/hass-addon-sunsynk-dev/config.yaml
+++ b/hass-addon-sunsynk-dev/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk Inverter Add-on (dev)
-version: 2022.08.29-0.2.5
+version: 2022.08.30-0.2.5
 slug: hass-addon-sunsynk-dev
 description: Add-on for the Sunsynk Inverter
 startup: services

--- a/hass-addon-sunsynk-dev/config.yaml
+++ b/hass-addon-sunsynk-dev/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk Inverter Add-on (dev)
-version: 2022.08.27-0.2.4
+version: 2022.08.29-0.2.5
 slug: hass-addon-sunsynk-dev
 description: Add-on for the Sunsynk Inverter
 startup: services

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -145,7 +145,8 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
                     command_topic=command_topic,
                     min=float(sensor.min_value),
                     max=float(sensor.max_value),
-                    on_change=create_on_change_handler(filt, int),
+                    on_change=create_on_change_handler(filt, float),
+                    step=0.1 if sensor.factor < 1 else 1,
                 )
             )
             continue

--- a/sunsynk/__init__.py
+++ b/sunsynk/__init__.py
@@ -4,4 +4,4 @@
 from .sensor import Sensor, group_sensors, update_sensors
 from .sunsynk import Sunsynk
 
-VERSION = "0.2.4"
+VERSION = "0.2.5"

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -6,7 +6,6 @@ from sunsynk.sensor import (
     InverterStateSensor,
     MathSensor,
     NumberRWSensor,
-    RWSensor,
     SDStatusSensor,
     SelectRWSensor,
     Sensor,
@@ -146,18 +145,67 @@ _SENSORS += (
 ###########
 _SENSORS += (
     Sensor(200, "Control Mode"),
-    Sensor(201, "Equalization voltage", VOLT, 0.01),
-    Sensor(202, "Absorption voltage", VOLT, 0.01),
     Sensor(230, "Grid Charge Battery current", AMPS, -1),
     Sensor(232, "Grid Charge enabled", "", -1),
     Sensor(312, "Battery charging voltage", VOLT, 0.01),
     Sensor(603, "Bat1 SOC", "%"),
     Sensor(611, "Bat1 Cycle"),
 )
-BATTERY_SHUTDOWN_CAPACITY = RWSensor(217, "Battery Shutdown Capacity", "%")
-BATTERY_RESTART_CAPACITY = RWSensor(218, "Battery Restart Capacity", "%")
-BATTERY_LOW_CAPACITY = RWSensor(219, "Battery Low Capacity", "%")
-_SENSORS += (BATTERY_SHUTDOWN_CAPACITY, BATTERY_RESTART_CAPACITY, BATTERY_LOW_CAPACITY)
+
+# Absolute min and max voltage based on Deye inverter
+MIN_VOLTAGE = 41
+MAX_VOLTAGE = 60
+
+EQUALIZATION_VOLTAGE = NumberRWSensor(
+    201, "Equalization voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
+)
+ABSORPTION_VOLTAGE = NumberRWSensor(
+    202, "Absorption voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
+)
+FLOAT_VOLTAGE = NumberRWSensor(
+    203, "Float voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
+)
+
+BATTERY_SHUTDOWN_CAPACITY = NumberRWSensor(217, "Battery Shutdown Capacity", "%")
+BATTERY_RESTART_CAPACITY = NumberRWSensor(218, "Battery Restart Capacity", "%")
+BATTERY_LOW_CAPACITY = NumberRWSensor(
+    219,
+    "Battery Low Capacity",
+    "%",
+    min=BATTERY_SHUTDOWN_CAPACITY,
+    max=BATTERY_RESTART_CAPACITY,
+)
+BATTERY_SHUTDOWN_CAPACITY.max = BATTERY_LOW_CAPACITY
+BATTERY_RESTART_CAPACITY.min = BATTERY_LOW_CAPACITY
+
+BATTERY_SHUTDOWN_VOLTAGE = NumberRWSensor(
+    220, "Battery Shutdown voltage", VOLT, 0.01, min=MIN_VOLTAGE
+)
+BATTERY_RESTART_VOLTAGE = NumberRWSensor(
+    221, "Battery Restart voltage", VOLT, 0.01, max=MAX_VOLTAGE
+)
+BATTERY_LOW_VOLTAGE = NumberRWSensor(
+    222,
+    "Battery Low voltage",
+    VOLT,
+    0.01,
+    min=BATTERY_SHUTDOWN_VOLTAGE,
+    max=BATTERY_RESTART_VOLTAGE,
+)
+BATTERY_SHUTDOWN_VOLTAGE.max = BATTERY_LOW_VOLTAGE
+BATTERY_RESTART_VOLTAGE.min = BATTERY_LOW_VOLTAGE
+
+_SENSORS += (
+    EQUALIZATION_VOLTAGE,
+    ABSORPTION_VOLTAGE,
+    FLOAT_VOLTAGE,
+    BATTERY_SHUTDOWN_CAPACITY,
+    BATTERY_RESTART_CAPACITY,
+    BATTERY_LOW_CAPACITY,
+    BATTERY_SHUTDOWN_VOLTAGE,
+    BATTERY_RESTART_VOLTAGE,
+    BATTERY_LOW_VOLTAGE,
+)
 
 #################
 # System program
@@ -179,6 +227,12 @@ PROG4_TIME.max = PROG5_TIME
 PROG5_TIME.max = PROG6_TIME
 PROG6_TIME.max = PROG1_TIME
 
+PROG_CHARGE_OPTIONS = {
+    4: "No Grid or Gen",
+    5: "Allow Grid",
+    6: "Allow Gen",
+    7: "Allow Grid & Gen",
+}
 PROGRAM = (
     PROG1_TIME,
     PROG2_TIME,
@@ -198,22 +252,33 @@ PROGRAM = (
     NumberRWSensor(271, "Prog4 Capacity", "%", min=BATTERY_LOW_CAPACITY),
     NumberRWSensor(272, "Prog5 Capacity", "%", min=BATTERY_LOW_CAPACITY),
     NumberRWSensor(273, "Prog6 Capacity", "%", min=BATTERY_LOW_CAPACITY),
-    # 1- Grid, 2- Gen
-    RWSensor(274, "Prog1 Charge"),
-    RWSensor(275, "Prog2 Charge"),
-    RWSensor(276, "Prog3 Charge"),
-    RWSensor(277, "Prog4 Charge"),
-    RWSensor(278, "Prog5 Charge"),
-    RWSensor(279, "Prog6 Charge"),
+    SelectRWSensor(274, "Prog1 Charge", options=PROG_CHARGE_OPTIONS),
+    SelectRWSensor(275, "Prog2 Charge", options=PROG_CHARGE_OPTIONS),
+    SelectRWSensor(276, "Prog3 Charge", options=PROG_CHARGE_OPTIONS),
+    SelectRWSensor(277, "Prog4 Charge", options=PROG_CHARGE_OPTIONS),
+    SelectRWSensor(278, "Prog5 Charge", options=PROG_CHARGE_OPTIONS),
+    SelectRWSensor(279, "Prog6 Charge", options=PROG_CHARGE_OPTIONS),
 )
 _SENSORS.extend(PROGRAM)
 PROG_VOLT = (
-    RWSensor(262, "Prog1 voltage", VOLT, 0.1),
-    RWSensor(263, "Prog2 voltage", VOLT, 0.1),
-    RWSensor(264, "Prog3 voltage", VOLT, 0.1),
-    RWSensor(265, "Prog4 voltage", VOLT, 0.1),
-    RWSensor(266, "Prog5 voltage", VOLT, 0.1),
-    RWSensor(267, "Prog6 voltage", VOLT, 0.1),
+    NumberRWSensor(
+        262, "Prog1 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+    ),
+    NumberRWSensor(
+        263, "Prog2 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+    ),
+    NumberRWSensor(
+        264, "Prog3 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+    ),
+    NumberRWSensor(
+        265, "Prog4 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+    ),
+    NumberRWSensor(
+        266, "Prog5 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+    ),
+    NumberRWSensor(
+        267, "Prog6 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+    ),
 )
 _SENSORS.extend(PROG_VOLT)
 

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -156,14 +156,14 @@ _SENSORS += (
 MIN_VOLTAGE = 41
 MAX_VOLTAGE = 60
 
-EQUALIZATION_VOLTAGE = NumberRWSensor(
-    201, "Equalization voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
+BATTERY_EQUALIZATION_VOLTAGE = NumberRWSensor(
+    201, "Battery Equalization voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
 )
-ABSORPTION_VOLTAGE = NumberRWSensor(
-    202, "Absorption voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
+BATTERY_ABSORPTION_VOLTAGE = NumberRWSensor(
+    202, "Battery Absorption voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
 )
-FLOAT_VOLTAGE = NumberRWSensor(
-    203, "Float voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
+BATTERY_FLOAT_VOLTAGE = NumberRWSensor(
+    203, "Battery Float voltage", VOLT, 0.01, min=MIN_VOLTAGE, max=MAX_VOLTAGE
 )
 
 BATTERY_SHUTDOWN_CAPACITY = NumberRWSensor(217, "Battery Shutdown Capacity", "%")
@@ -196,9 +196,9 @@ BATTERY_SHUTDOWN_VOLTAGE.max = BATTERY_LOW_VOLTAGE
 BATTERY_RESTART_VOLTAGE.min = BATTERY_LOW_VOLTAGE
 
 _SENSORS += (
-    EQUALIZATION_VOLTAGE,
-    ABSORPTION_VOLTAGE,
-    FLOAT_VOLTAGE,
+    BATTERY_EQUALIZATION_VOLTAGE,
+    BATTERY_ABSORPTION_VOLTAGE,
+    BATTERY_FLOAT_VOLTAGE,
     BATTERY_SHUTDOWN_CAPACITY,
     BATTERY_RESTART_CAPACITY,
     BATTERY_LOW_CAPACITY,
@@ -262,22 +262,52 @@ PROGRAM = (
 _SENSORS.extend(PROGRAM)
 PROG_VOLT = (
     NumberRWSensor(
-        262, "Prog1 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+        262,
+        "Prog1 voltage",
+        VOLT,
+        0.01,
+        min=BATTERY_LOW_VOLTAGE,
+        max=BATTERY_FLOAT_VOLTAGE,
     ),
     NumberRWSensor(
-        263, "Prog2 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+        263,
+        "Prog2 voltage",
+        VOLT,
+        0.01,
+        min=BATTERY_LOW_VOLTAGE,
+        max=BATTERY_FLOAT_VOLTAGE,
     ),
     NumberRWSensor(
-        264, "Prog3 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+        264,
+        "Prog3 voltage",
+        VOLT,
+        0.01,
+        min=BATTERY_LOW_VOLTAGE,
+        max=BATTERY_FLOAT_VOLTAGE,
     ),
     NumberRWSensor(
-        265, "Prog4 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+        265,
+        "Prog4 voltage",
+        VOLT,
+        0.01,
+        min=BATTERY_LOW_VOLTAGE,
+        max=BATTERY_FLOAT_VOLTAGE,
     ),
     NumberRWSensor(
-        266, "Prog5 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+        266,
+        "Prog5 voltage",
+        VOLT,
+        0.01,
+        min=BATTERY_LOW_VOLTAGE,
+        max=BATTERY_FLOAT_VOLTAGE,
     ),
     NumberRWSensor(
-        267, "Prog6 voltage", VOLT, 0.01, min=BATTERY_LOW_VOLTAGE, max=FLOAT_VOLTAGE
+        267,
+        "Prog6 voltage",
+        VOLT,
+        0.01,
+        min=BATTERY_LOW_VOLTAGE,
+        max=BATTERY_FLOAT_VOLTAGE,
     ),
 )
 _SENSORS.extend(PROG_VOLT)
@@ -316,6 +346,8 @@ def _deprecated() -> None:
         "total_load_energy": Sensor((85, 86), "Total Load Power", KWH, 0.1),
         "year_load_energy": Sensor((87, 88), "Year Load Power", KWH, 0.1),
         "total_pv_energy": Sensor((96, 97), "Total PV Power", KWH, 0.1),
+        "battery_equalization_voltage": Sensor(201, "Equalization voltage", VOLT, 0.01),
+        "battery_absorption_voltage": Sensor(202, "Absorption voltage", VOLT, 0.01),
     }
 
     for newname, sen in dep_map.items():

--- a/sunsynk/sensor.py
+++ b/sunsynk/sensor.py
@@ -144,8 +144,8 @@ class RWSensor(Sensor):
 class NumberRWSensor(RWSensor):
     """Numeric sensor which can be read and written."""
 
-    min: int | Sensor = attr.field(default=0)
-    max: int | Sensor = attr.field(default=100)
+    min: int | float | Sensor = attr.field(default=0)
+    max: int | float | Sensor = attr.field(default=100)
 
     @property
     def min_value(self) -> int | float:
@@ -166,7 +166,7 @@ class NumberRWSensor(RWSensor):
             sensors.append(self.max)
         return sensors
 
-    def value_to_reg(self, value: int) -> int | Tuple[int, ...]:
+    def value_to_reg(self, value: int | float) -> int | Tuple[int, ...]:
         """Get the reg value from a display value, or the current reg value if out of range."""
         if value < self.min_value or value > self.max_value:
             # Return current reg_value if value is out of range
@@ -175,7 +175,7 @@ class NumberRWSensor(RWSensor):
         return int(value / abs(self.factor))
 
     @staticmethod
-    def _static_or_sensor_value(val: int | Sensor) -> int | float:
+    def _static_or_sensor_value(val: int | float | Sensor) -> int | float:
         if isinstance(val, Sensor):
             if isinstance(val.value, (int, float)):
                 return val.value

--- a/tests/sunsynk/test_sensor.py
+++ b/tests/sunsynk/test_sensor.py
@@ -185,11 +185,21 @@ def test_number_rw() -> None:
     assert s.update_reg_value(-1) is False
     assert s.reg_value == (25,)
 
-    s = NumberRWSensor(1, "", factor=0.1)
-    s.reg_to_value(485)
+    s = NumberRWSensor(1, "", factor=0.01)
+    s.reg_to_value(4850)
     assert s.value == 48.5
     s.update_reg_value(50)
-    assert s.reg_value == (500,)
+    assert s.reg_value == (5000,)
+    s.update_reg_value(50.1)
+    assert s.reg_value == (5010,)
+
+    s.min = Sensor(2, "2", factor=0.01)
+    s.min.reg_to_value(4710)
+    assert s.min_value == 47.1
+
+    s.max = Sensor(3, "3", factor=0.01)
+    s.max.reg_to_value(5450)
+    assert s.max_value == 54.5
 
 
 def test_select_rw() -> None:


### PR DESCRIPTION
Resolves #37 

This is the final PR dealing with writable sensors in #37.

The salient changes here are:

  - Introduced new `Battery Shutdown voltage`, `Battery Restart voltage` and `Battery Low Voltage` sensors
  - Introduced new `Float voltage` sensor upon which the `Prog1-6 Voltage` sensors depend for their `max` value
  - Made `Prog1-6 Charge` and `Prog1-6 Voltage` sensors writable
    <img width="366" alt="image" src="https://user-images.githubusercontent.com/16413523/187090226-be477273-1ddd-4c15-a60c-da46f193bcba.png">
  - Made `Equalization voltage` and `Absorption voltage` writable
  - Made `Battery Shutdown Capacity`, `Battery Restart Capacity` and `Battery Low Capacity` writable
  - Corrected `Prog1-6 Voltage` factor to be 0.01 (this was previously 0.1 which was incorrect)

If the `definitions.py` file can be formatted better, please do let me know.

My one wish from the Home Assistant [MQTT Number integration](https://www.home-assistant.io/integrations/number.mqtt/) is for it to support the `mode` configuration variable of [Number Entity](https://developers.home-assistant.io/docs/core/entity/number/) so that the voltage entities can be set to `box`. Currently the unchangeable `auto` value causes a `slider` to be used which is not wrong, but when dealing with voltage values I think the more correct control to use is `box`. I will  file a request for the MQTT Number integration to gain a `mode` configuration variable.

<img width="298" alt="image" src="https://user-images.githubusercontent.com/16413523/187090171-80c89245-cf57-464f-ba99-7f0c2de4db60.png">
