### PR TITLE
Allow NumberEntity mode to be customized

### DIFF
--- a/hass-addon-sunsynk-dev/CHANGELOG.md
+++ b/hass-addon-sunsynk-dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## **2022.09.16-0.2.5** - 2022-09-16
+
+- Sunsynk Dev Add-On
+
+  - Allow for customizing the `mode` of NumberEntity sensors allowing for forcing either `box` or `slider` mode instead of the default `auto` - requires Home Assistant 2022.9.0 for the effect to be seen - [#58](https://github.com/kellerza/sunsynk/pull/58)
+
 ## **2022.09.15-0.2.5** - 2022-09-15
 
 - Sunsynk Dev Add-On

--- a/hass-addon-sunsynk-dev/DOCS.md
+++ b/hass-addon-sunsynk-dev/DOCS.md
@@ -88,6 +88,10 @@
 
   A list of sensors to poll. You can use any sensor defined in the sunsynk Python library - [here](https://github.com/kellerza/sunsynk/blob/main/sunsynk/definitions.py).
 
+- `NUMBER_ENTITY_MODE`
+
+  When adding read/write sensors which present as number entities in Home Assistant, the default display mode is `auto`. This setting controls how the number entity should be displayed in the UI. Can be set to `box` or `slider` to force a display mode.
+
 - `MQTT_*`
 
   You will need a working MQTT sevrer since all values will be sent via MQTT.

--- a/hass-addon-sunsynk-dev/config.yaml
+++ b/hass-addon-sunsynk-dev/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk Inverter Add-on (dev)
-version: 2022.09.15-0.2.5
+version: 2022.09.16-0.2.5
 slug: hass-addon-sunsynk-dev
 description: Add-on for the Sunsynk Inverter
 startup: services
@@ -32,6 +32,7 @@ options:
     - total_grid_import
     - battery_soc
   READ_SENSORS_BATCH_SIZE: 60
+  NUMBER_ENTITY_MODE: "auto"
   PROFILES: []
   MODBUS_SERVER_ID: 1
   MQTT_HOST: core-mosquitto
@@ -48,6 +49,7 @@ schema:
   SENSORS:
     - str
   READ_SENSORS_BATCH_SIZE: int?
+  NUMBER_ENTITY_MODE: list(auto|box|slider)?
   PROFILES:
     - str
   MODBUS_SERVER_ID: int

--- a/hass-addon-sunsynk-dev/mqtt.py
+++ b/hass-addon-sunsynk-dev/mqtt.py
@@ -133,6 +133,7 @@ class NumberEntity(Entity):
     command_topic: str = attr.field(default=None, validator=required)
     min: float = attr.field(default=0.0)
     max: float = attr.field(default=100.0)
+    mode: float = attr.field(default="auto")
     step: float = attr.field(default=1.0)
 
     on_change: Callable = attr.field(default=None)

--- a/hass-addon-sunsynk-dev/options.py
+++ b/hass-addon-sunsynk-dev/options.py
@@ -17,6 +17,7 @@ class Options:
     mqtt_port: int = 0
     mqtt_username: str = ""
     mqtt_password: str = ""
+    number_entity_mode: str = "auto"
     sunsynk_id: str = ""
     sensors: List[str] = []
     read_sensors_batch_size: int = 60

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -144,7 +144,7 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
                     command_topic=command_topic,
                     min=float(sensor.min_value),
                     max=float(sensor.max_value),
-                    mode="box",
+                    mode=OPT.number_entity_mode,
                     on_change=create_on_change_handler(filt, float),
                     step=0.1 if sensor.factor < 1 else 1,
                 )

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -144,6 +144,7 @@ def create_entities(sensors: list[Filter], dev: Device) -> list[Entity]:
                     command_topic=command_topic,
                     min=float(sensor.min_value),
                     max=float(sensor.max_value),
+                    mode="box",
                     on_change=create_on_change_handler(filt, float),
                     step=0.1 if sensor.factor < 1 else 1,
                 )


### PR DESCRIPTION
As part of #37 the `NumberRWSensor` was introduced which mapped to the Home Assistant [MQTT Number Integration](https://www.home-assistant.io/integrations/number.mqtt/) entity. At the time, one could not set the `mode` of this entity so this resulted in the `mode` being `auto` for all `NumberRWSensor`s and nearly all of them got displayed as sliders. As of Home Assistant 2022.9.0, `mode` [can be customised](https://github.com/home-assistant/core/issues/77455) and this PR allows for the `mode` to be customised for `NumberRWSensor`s via an option in the add-on.

Before:
<img width="304" alt="image" src="https://user-images.githubusercontent.com/16413523/188262087-2823beee-31e5-4308-8dd7-6a65d4f93b45.png">

After (if setting the `mode` to `box`):
<img width="319" alt="image" src="https://user-images.githubusercontent.com/16413523/188362730-ce3ab1f7-18d3-4967-828a-cf035d854d3c.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/16413523/188362819-23312f97-1ec6-4aa5-a4b3-941732936e9a.png">

Note: If users do not have HA 2022.9.0, the `mode` field is ignored, therefore this is not a breaking change.