### PR TITLE
Fix prog charge options

### DIFF
--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -235,10 +235,10 @@ PROG5_TIME.max = PROG6_TIME
 PROG6_TIME.max = PROG1_TIME
 
 PROG_CHARGE_OPTIONS = {
-    4: "No Grid or Gen",
-    5: "Allow Grid",
-    6: "Allow Gen",
-    7: "Allow Grid & Gen",
+    0: "No Grid or Gen",
+    1: "Allow Grid",
+    2: "Allow Gen",
+    3: "Allow Grid & Gen",
 }
 PROGRAM = (
     PROG1_TIME,


### PR DESCRIPTION
Currently used values for PROG_CHARGE_OPTIONS set bit 2 high which does not seem to be correct (sunsynk app only uses bits 0 (grid charge) and 1 (gen charge))
