### PR TITLE
Essential power test sensors & timeouts

### DIFF
--- a/hass-addon-sunsynk-dev/CHANGELOG.md
+++ b/hass-addon-sunsynk-dev/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## **2023.01.12-0.2.7** - 2022-11-29
+## **2023.01.18-0.2.8**
+
+- Python sunsynk module 0.2.8:
+  - MathSensor absolute mode
+
+- Sunsynk Dev Add-On:
+  - Add non-essential test sensors
+
+## **2023.01.12-0.2.7**
 
 - Python sunsynk module 0.2.7:
   - Add bitmask sensors to support Modes (GM/BM/CM)
@@ -8,7 +16,7 @@
 - Sunsynk Dev Add-On:
   - Update to use the latest sensors
 
-## **2023.01.02-0.2.6** - 2022-11-29
+## **2023.01.02-0.2.6**
 
 - Python sunsynk module 0.2.6:
   - Add Load Limit RW Sensor (Zero Export & Limit to Load)
@@ -17,7 +25,7 @@
   - Always update config entity state after discovery
   - Round floats to 3 decomal place instead of 2
 
-## **2022.12.29b-0.2.5** - 2022-11-29
+## **2022.12.29b-0.2.5**
 
 - Sunsynk Dev Add-On:
   - Deprecate PROFILES (System Mode & System Mode Voltages)

--- a/hass-addon-sunsynk-dev/DOCS.md
+++ b/hass-addon-sunsynk-dev/DOCS.md
@@ -40,6 +40,8 @@
       DRIVER: pymodbus
       ```
 
+  `DEVICE` allows you to select the USB port in the UI. It will only be used if `PORT` is empty.
+
 - `SUNSYNK_ID`
 
   The serial number of your inverter. When you start the add-on the connected serial will be displayed in the log.
@@ -55,34 +57,6 @@
 - `SENSOR_PREFIX`
 
   A prefix to add to all the MQTT Discovered Home Assistant Sensors (default: SS).
-
-- `PROFILES`
-
-  > BETA!!
-  >
-  > This writes settings, use at your own risk!
-
-  Read & Write settings to your inverter.
-
-  The profiles will be presented as a Home Assistant Select Entity, with options for the different profiles.
-
-  Available profiles:
-
-  | Profile              | Description                                                                              |
-  | -------------------- | ---------------------------------------------------------------------------------------- |
-  | system_mode          | The system mode, including time, grid charging, target SOC.                              |
-  | system_mode_voltages | The system mode charging voltages (likely used when you dont have a Battery with a BMS). |
-
-  The Inverter setting is only read when the Add-On starts, if you want to force re-reading the inverter settings and any configuration, choose the **UPDATE** option in the Select Entity. (You can schedule **UPDATE** through automations if this is important for you)
-
-  When you **UPDATE** a profile, the Add-On performs the following actions:
-  - Read all the settings related to the profile from the Inverter.
-  - Read all the profile presets from `/share/hass-addon-sunsynk/*.yml`
-  - The value of the Home Assistant Select entity will reflect the matching presets.
-    - If the current settings is not part of existing presets, a new profile will be created.
-
-      You can customize the name of the presets in the Yaml files (followed by an **UPDATE**).
-      One option to access these files is though the Samba Add-On.
 
 - `SENSORS`
 

--- a/hass-addon-sunsynk-dev/Dockerfile
+++ b/hass-addon-sunsynk-dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
-RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.7
+RUN pip3 install --no-cache-dir --disable-pip-version-check paho-mqtt~=1.5.0 pyyaml~=5.4.1 sunsynk[pymodbus,umodbus]==0.2.8
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/hass-addon-sunsynk-dev/config.yaml
+++ b/hass-addon-sunsynk-dev/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk Inverter Add-on (dev)
-version: 2023.01.12-0.2.7
+version: 2023.01.18-0.2.8
 slug: hass-addon-sunsynk-dev
 description: Add-on for the Sunsynk Inverter
 startup: services

--- a/hass-addon-sunsynk-dev/filter.py
+++ b/hass-addon-sunsynk-dev/filter.py
@@ -195,10 +195,10 @@ def suggested_filter(sensor: Sensor) -> str:
         return "round_robin"
     f_id = {
         "battery_soc": "last",
-        "fault": "round_robin",
+        "fault": "last",
         "grid_connected_status": "last",
-        "overall_state": "step",
-        "sd_status": "step",
+        "overall_state": "last",
+        "sd_status": "last",
         "serial": "round_robin",
     }
     assert all(s in ALL_SENSORS for s in f_id)

--- a/hass-addon-sunsynk-dev/run.py
+++ b/hass-addon-sunsynk-dev/run.py
@@ -24,7 +24,7 @@ from mqtt import (
 )
 from options import OPT, SS_TOPIC
 
-from sunsynk.definitions import ALL_SENSORS, DEPRECATED, RATED_POWER
+from sunsynk.definitions import ALL_SENSORS, DEPRECATED, RATED_POWER, WATT, MathSensor
 from sunsynk.helpers import slug
 from sunsynk.rwsensors import NumberRWSensor, RWSensor, SelectRWSensor, TimeRWSensor
 from sunsynk.sunsynk import Sensor, Sunsynk
@@ -254,7 +254,22 @@ def startup() -> None:
             force=True,
         )
 
+    # Add test sensors
+    for sen in TEST_SENSORS:
+        ALL_SENSORS[sen.id] = sen
+
     setup_sensors()
+
+
+TEST_SENSORS = (
+    MathSensor(
+        (175, 167, 166), "Essential abs power", WATT, factors=(1, 1, -1), absolute=True
+    ),
+    # https://powerforum.co.za/topic/8646-my-sunsynk-8kw-data-collection-setup/?do=findComment&comment=147591
+    MathSensor(
+        (175, 169, 166), "Essential l2 power", WATT, factors=(1, 1, -1), absolute=True
+    ),
+)
 
 
 def setup_sensors() -> None:

--- a/sunsynk/__init__.py
+++ b/sunsynk/__init__.py
@@ -4,4 +4,4 @@
 from .sensors import Sensor, group_sensors
 from .sunsynk import Sunsynk, update_sensors
 
-VERSION = "0.2.7"
+VERSION = "0.2.8"

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -92,14 +92,14 @@ _SENSORS += (
         (172, 167), "Non-Essential power", WATT, factors=(1, -1), no_negative=True
     ),
     MathSensor(
-        (175, 167, 166), "Essential power abs", WATT, factors=(1, 1, -1), absolute=True
+        (175, 167, 166), "Essential abs power", WATT, factors=(1, 1, -1), absolute=True
     ),
     # https://powerforum.co.za/topic/8646-my-sunsynk-8kw-data-collection-setup/?do=findComment&comment=147591
     MathSensor(
-        (175, 169, 166), "Essential power l2", WATT, factors=(1, 1, -1), absolute=True
+        (175, 169, 166), "Essential l2 power", WATT, factors=(1, 1, -1), absolute=True
     ),
     MathSensor(
-        (172, 167), "Non-Essential power abs", WATT, factors=(1, -1), absolute=True
+        (172, 167), "Non-Essential abs power", WATT, factors=(1, -1), absolute=True
     ),
 )
 

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -91,16 +91,6 @@ _SENSORS += (
     MathSensor(
         (172, 167), "Non-Essential power", WATT, factors=(1, -1), no_negative=True
     ),
-    MathSensor(
-        (175, 167, 166), "Essential abs power", WATT, factors=(1, 1, -1), absolute=True
-    ),
-    # https://powerforum.co.za/topic/8646-my-sunsynk-8kw-data-collection-setup/?do=findComment&comment=147591
-    MathSensor(
-        (175, 169, 166), "Essential l2 power", WATT, factors=(1, 1, -1), absolute=True
-    ),
-    MathSensor(
-        (172, 167), "Non-Essential abs power", WATT, factors=(1, -1), absolute=True
-    ),
 )
 
 ###################

--- a/sunsynk/definitions.py
+++ b/sunsynk/definitions.py
@@ -91,6 +91,16 @@ _SENSORS += (
     MathSensor(
         (172, 167), "Non-Essential power", WATT, factors=(1, -1), no_negative=True
     ),
+    MathSensor(
+        (175, 167, 166), "Essential power abs", WATT, factors=(1, 1, -1), absolute=True
+    ),
+    # https://powerforum.co.za/topic/8646-my-sunsynk-8kw-data-collection-setup/?do=findComment&comment=147591
+    MathSensor(
+        (175, 169, 166), "Essential power l2", WATT, factors=(1, 1, -1), absolute=True
+    ),
+    MathSensor(
+        (172, 167), "Non-Essential power abs", WATT, factors=(1, -1), absolute=True
+    ),
 )
 
 ###################

--- a/sunsynk/sensors.py
+++ b/sunsynk/sensors.py
@@ -84,6 +84,8 @@ class MathSensor(Sensor):
         self.value = int_round(
             sum(signed(i) * s for i, s in zip(self.reg_value, self.factors))
         )
+        if self.absolute and not isinstance(self.value, str) and self.value < 0:
+            self.value = -self.value
         if self.no_negative and not isinstance(self.value, str) and self.value < 0:
             self.value = 0
 

--- a/sunsynk/sensors.py
+++ b/sunsynk/sensors.py
@@ -77,6 +77,7 @@ class MathSensor(Sensor):
 
     factors: Tuple[float, ...] = attr.field(default=None, converter=ensure_tuple)
     no_negative: bool = attr.field(default=False)
+    absolute: bool = attr.field(default=False)
 
     def update_value(self) -> None:
         """Update the value."""

--- a/sunsynk/usunsynk.py
+++ b/sunsynk/usunsynk.py
@@ -31,7 +31,13 @@ class uSunsynk(Sunsynk):  # pylint: disable=invalid-name
                 + ", ".join(sks)
             )
 
-        self.client = modbus_for_url(self.port)
+        self.client = modbus_for_url(
+            self.port,
+            {
+                "connection_timeout": self.timeout,  # sockio.TCP
+                "timeout": self.timeout,  # sockio.TCP
+            },
+        )
 
     async def write_register(self, *, address: int, value: int) -> bool:
         """Write to a register - Sunsynk support function code 0x10."""
@@ -42,7 +48,7 @@ class uSunsynk(Sunsynk):  # pylint: disable=invalid-name
                     starting_address=address,
                     values=(value,),
                 ),
-                timeout=10,
+                timeout=self.timeout,
             )
             return True
         except asyncio.TimeoutError:

--- a/tests/hass-addon-sunsynk-dev/test_filter.py
+++ b/tests/hass-addon-sunsynk-dev/test_filter.py
@@ -165,7 +165,7 @@ def test_suggest(filters):
     assert filters.suggested_filter(ALL_SENSORS["temp_environment"]) == "avg"
     assert filters.suggested_filter(ALL_SENSORS["day_battery_charge"]) == "last"
     assert filters.suggested_filter(ALL_SENSORS["grid_load"]) == "step"
-    assert filters.suggested_filter(ALL_SENSORS["sd_status"]) == "step"
+    assert filters.suggested_filter(ALL_SENSORS["sd_status"]) == "last"
 
     rw_sensors = [s for s in ALL_SENSORS.values() if isinstance(s, RWSensor)]
     for s in rw_sensors:

--- a/tests/sunsynk/test_sensors.py
+++ b/tests/sunsynk/test_sensors.py
@@ -117,6 +117,11 @@ def test_math() -> None:
     assert s.reg_to_value((200, 800)) == -600
     s.no_negative = True
     assert s.reg_to_value((200, 800)) == 0
+    s.no_negative = False
+    s.absolute = True
+    assert s.reg_to_value((200, 800)) == 600
+    s = MathSensor((1, 2), "", "", factors=(1, -1), absolute=True)
+    assert s.reg_to_value((200, 800)) == 600
 
 
 def test_update_func() -> None:

--- a/tests/sunsynk/test_sunsynk.py
+++ b/tests/sunsynk/test_sunsynk.py
@@ -71,9 +71,12 @@ async def test_ss_NotImplemented():
 @patch("sunsynk.Sunsynk.write_register")
 async def test_ss_write_sensor(rhr: MagicMock, wreg: MagicMock):
     ss = Sunsynk()
-    sen = NumberRWSensor((1,), "", min=1, max=10)
-    sen.reg_value = (99,)
+    sen = NumberRWSensor((1, 2), "", min=1, max=10)
+    sen.reg_value = (99, 98)
     await ss.write_sensor(sen)
+
+    # with pytest.raises(NotImplementedError):
+    await ss.read_holding_registers(1, 1)
 
     # test a sensor with a bitmask
     sen = NumberRWSensor((1,), "", min=1, max=10, bitmask=0x3)
@@ -97,6 +100,13 @@ async def test_ss_read_sensor(rhr: MagicMock):
     rhr.side_effect = Exception("a")
     with pytest.raises(Exception):
         await ss.read_sensors([sen])
+
+
+@pytest.mark.asyncio
+async def test_ss_rhr():
+    ss = Sunsynk()
+    with pytest.raises(NotImplementedError):
+        await ss.read_holding_registers(1, 1)
 
 
 def test_update_sensor(caplog) -> None:


### PR DESCRIPTION
- Add usunsynk timeouts for #60
- Added 2 test sensors for #75
  - essential_abs_power
  - essential_l2_power
- Removed deprecated `PROFILES` from the docs