### PR TITLE
Signed NumberRWSensor

### DIFF
--- a/sunsynk/helpers.py
+++ b/sunsynk/helpers.py
@@ -48,7 +48,7 @@ def as_num(val: ValType) -> Union[float, int]:
 
 def signed(val: Union[int, float]) -> Union[int, float]:
     """Convert 16-bit value to signed int."""
-    return val if val <= 0x7FFF else val - 0xFFFF
+    return val if val <= 0x7FFF else val - 0x10000
 
 
 def slug(name: str) -> str:

--- a/sunsynk/rwsensors.py
+++ b/sunsynk/rwsensors.py
@@ -73,6 +73,8 @@ class NumberRWSensor(RWSensor):
         maxv = resolve_num(resolve, self.max, 100)
         val = int(max(minv, min(maxv, fval / abs(self.factor))))
         if len(self.address) == 1:
+            if val < 0:
+                val = 0x10000 + val
             return self.reg(val)
         if len(self.address) == 2:
             return self.reg(val & 0xFFFF, int(val >> 16))

--- a/tests/sunsynk/test_helpers.py
+++ b/tests/sunsynk/test_helpers.py
@@ -36,14 +36,18 @@ def test_int_round() -> None:
 
 def test_signed() -> None:
     assert signed(0x7FFF) == 0x7FFF
-    assert signed(0xFFFF) == 0
+    assert signed(0xFFFF) == -1
+    assert signed(0) == 0
+    assert signed(32767) == 32767
+    assert signed(32768) == -32768
 
 
 def test_signeds() -> None:
     """Signed sensors have a -1 factor"""
     s = Sensor(1, "", "", factor=-1)
     assert s.reg_to_value((1,)) == 1
-    assert s.reg_to_value((0xFFFE,)) == -1
+    assert s.reg_to_value((0xFFFE,)) == -2
+    assert s.reg_to_value((0xFFBA,)) == -70
 
     s = Sensor(1, "", "", factor=1)
     assert s.reg_to_value((1,)) == 1

--- a/tests/sunsynk/test_rwsensors.py
+++ b/tests/sunsynk/test_rwsensors.py
@@ -90,6 +90,10 @@ def test_number_rw(state) -> None:
     assert s.value_to_reg(500, state.get) == (300,)
     assert s.value_to_reg(-1, state.get) == (1,)
 
+    # writing negative values (when allowed by min)
+    s.min = -10
+    assert s.value_to_reg(-1, state.get) == (65535,)
+
     s = NumberRWSensor(1, "s2", factor=0.01)
     state.track(s)
 


### PR DESCRIPTION
Fixes #145 and allow reading & writing negative NumberRWSensor (for single register sensors)

```python
NumberRWSensor(206, "Grid Trickle Feed", WATT, -1, min=-500, max=500)
```

