### PR TITLE
Update standalone deployment docs

### DIFF
--- a/www/docs/guide/standalone-deployment.md
+++ b/www/docs/guide/standalone-deployment.md
@@ -37,7 +37,7 @@ Use the one that is most appropriate for your host computer.
 * View container logs `docker compose logs -f mbusd`
 
 ## Using Pre-built Docker Images
-The repo also contains prebuilt Docker images for Sunsynk Multi. You can see the different images [here](https://github.com/kellerza?tab=packages&repo_name=sunsynk).
+The repo also contains prebuilt Docker images for Sunsynk Multi. You can see the different images for the various supported architectures [here](https://github.com/kellerza?tab=packages&repo_name=sunsynk).
 
 ### Docker-Compose examples:
 #### amd64

--- a/www/docs/guide/standalone-deployment.md
+++ b/www/docs/guide/standalone-deployment.md
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
     image: ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
     volumes:
-      - ${PWD}/options.yaml:/usr/src/.local.yaml
+      - ${PWD}/options.yaml:/data/options.yaml
 ```
 
 #### aarch64
@@ -57,7 +57,7 @@ services:
     restart: unless-stopped
     image: ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
     volumes:
-      - ${PWD}/options.yaml:/usr/src/.local.yaml
+      - ${PWD}/options.yaml:/data/options.yaml
 ```
 
 #### armv7
@@ -67,7 +67,7 @@ services:
     restart: unless-stopped
     image: ghcr.io/kellerza/hass-addon-sunsynk-multi/armv7:stable
     volumes:
-      - ${PWD}/options.yaml:/usr/src/.local.yaml
+      - ${PWD}/options.yaml:/data/options.yaml
 ```
 
 ### Docker CLI examples:
@@ -80,7 +80,7 @@ Below are examples using the docker CLI.
 ``` bash
 docker run -d --name sunsynk-multi \
 --restart unless-stopped \
--v ${PWD}/options.yaml:/usr/src/.local.yaml \
+-v ${PWD}/options.yaml:/data/options.yaml \
 ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
 ```
 
@@ -88,7 +88,7 @@ ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
 ``` bash
 docker run -d --name sunsynk-multi \
 --restart unless-stopped \
--v ${PWD}/options.yaml:/usr/src/.local.yaml \
+-v ${PWD}/options.yaml:/data/options.yaml \
 ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
 ```
 
@@ -96,7 +96,7 @@ ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
 ``` bash
 docker run -d --name sunsynk-multi \
 --restart unless-stopped \
--v ${PWD}/options.yaml:/usr/src/.local.yaml \
+-v ${PWD}/options.yaml:/data/options.yaml \
 ghcr.io/kellerza/hass-addon-sunsynk-multi/armv7:stable
 ```
 

--- a/www/docs/guide/standalone-deployment.md
+++ b/www/docs/guide/standalone-deployment.md
@@ -50,7 +50,7 @@ services:
       - ${PWD}/options.yaml:/usr/src/.local.yaml
 ```
 
-#### aarch63
+#### aarch64
 ``` yaml
 services:
   sunsynk-multi:
@@ -70,6 +70,30 @@ services:
       - ${PWD}/options.yaml:/usr/src/.local.yaml
 ```
 
+### Docker CLI examples:
 
+#### amd64
+``` bash
+docker run -d --name sunsynk-multi \
+--restart unless-stopped \
+-v ${PWD}/options.yaml:/usr/src/.local.yaml \
+ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
+```
+
+#### aarch64
+``` bash
+docker run -d --name sunsynk-multi \
+--restart unless-stopped \
+-v ${PWD}/options.yaml:/usr/src/.local.yaml \
+ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
+```
+
+#### armv7
+``` bash
+docker run -d --name sunsynk-multi \
+--restart unless-stopped \
+-v ${PWD}/options.yaml:/usr/src/.local.yaml \
+ghcr.io/kellerza/hass-addon-sunsynk-multi/armv7:stable
+```
 
 

--- a/www/docs/guide/standalone-deployment.md
+++ b/www/docs/guide/standalone-deployment.md
@@ -4,13 +4,13 @@ If you are running only Home Assistant Core, or do not have Home Assistant Super
 you might want to run this addon as a standalone service.
 Docker Compose is commonly used to manage services that run in docker containers.
 
-As a standalone service this addon does not depend on Home Assistant Core, Supervisor or OS.
-This means you can run this addon and send data to any MQTT server, without using any other HA services.
+As a standalone service, this addon does not depend on Home Assistant Core, Supervisor or OS.
+You can run this addon and send data to any MQTT server without using other HA services.
 
 Another benefit of this setup is to run this addon along with `mbusd` on a
 Raspberry Pi without having to install Home Assistant on it.
 
-## Base image
+## Local Docker-Compose Builds
 
 In these example commands we prefix the `docker-compose build` commands with the
 environment variable definition `BUILD_FROM=...`,
@@ -21,17 +21,55 @@ A list of available base images can be found in
 `hass-addon-sunsynk-multi/build.yaml` and `hass-addon-mbusd/build.yaml`.
 Use the one that is most appropriate for your host computer.
 
-## Sunsynk Multi
+### Sunsynk Multi
 
 * Copy `options.yaml.template` to `options.yaml` and make changes to `options.yaml` to match your setup. Use `PORT: tcp://mbusd:502` for the inverter port if you want to use the `mbusd` included in this docker compose stack.
 * Build the image `BUILD_FROM=<base_image> docker compose build sunsynk-multi`
 * Run the container `docker compose up -d sunsynk-multi`
 * See the container logs `docker compose logs -f sunsynk-multi`
 
-## Mbusd
+### Mbusd
 
 * Edit `docker-compose.yaml` changing the values under `environment` to match your configuration, leaving the device set to `/dev/ttyUSB0` as we mount the correct port to this location in the next step.
 * Under `volumes` change `/dev/ttyRS485` to the RS485 port of your host computer.
 * Build the image `BUILD_FROM=<base_image> docker compose build mbusd`
 * Run the container `docker compose up mbusd`
 * View container logs `docker compose logs -f mbusd`
+
+## Using Pre-built Docker Images
+The repo also contains prebuilt Docker images for Sunsynk Multi. You can see the different images [here](https://github.com/kellerza?tab=packages&repo_name=sunsynk).
+
+### Docker-Compose examples:
+#### amd64
+``` yaml
+services:
+  sunsynk-multi:
+    restart: unless-stopped
+    image: ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
+    volumes:
+      - ${PWD}/options.yaml:/usr/src/.local.yaml
+```
+
+#### aarch63
+``` yaml
+services:
+  sunsynk-multi:
+    restart: unless-stopped
+    image: ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
+    volumes:
+      - ${PWD}/options.yaml:/usr/src/.local.yaml
+```
+
+#### armv7
+``` yaml
+services:
+  sunsynk-multi:
+    restart: unless-stopped
+    image: ghcr.io/kellerza/hass-addon-sunsynk-multi/armv7:stable
+    volumes:
+      - ${PWD}/options.yaml:/usr/src/.local.yaml
+```
+
+
+
+

--- a/www/docs/guide/standalone-deployment.md
+++ b/www/docs/guide/standalone-deployment.md
@@ -71,6 +71,10 @@ services:
 ```
 
 ### Docker CLI examples:
+Below are examples using the docker CLI.
+
+> ℹ️ **Note:** Replace ${PWD} with the path to the location of your `options.yaml` file.
+
 
 #### amd64
 ``` bash


### PR DESCRIPTION
This PR updates the documentation around the stand-alone deployment options.

As discussed in issue #183 - there are now pre-built docker images that users can utilise to build a sunsynk-multi container. I have updated the docs to reflect these options and have included some docker CLI commands too. The pre-built images make it a viable option in building docker containers. 

I have also updated some minor grammar on the page. 

Happy to address anything else you may want updated @kellerza, while I'm kicking about in here. :) 