### PR TITLE
Added Solar Export configuration option

### DIFF
--- a/src/sunsynk/definitions.py
+++ b/src/sunsynk/definitions.py
@@ -223,7 +223,9 @@ SENSORS += (
         "Load Limit",
         options={0: "Allow Export", 1: "Essentials", 2: "Zero Export"},
     ),
-    # If disabled, does not allow the export of any excess solar. If enabled, will export any excess, but will also draw a constant ~40w at all times for an unknown reason
+    # If disabled, does not allow the export of any excess solar. 
+    # If enabled, will export any excess, but will also draw a 
+    # constant ~40w at all times for an unknown reason
     # 0: "Don't Sell", 1: "Sell solar"
     SwitchRWSensor(247, "Solar Export"),
     SwitchRWSensor(248, "Use Timer", bitmask=1),

--- a/src/sunsynk/definitions.py
+++ b/src/sunsynk/definitions.py
@@ -223,6 +223,9 @@ SENSORS += (
         "Load Limit",
         options={0: "Allow Export", 1: "Essentials", 2: "Zero Export"},
     ),
+    # If disabled, does not allow the export of any excess solar. If enabled, will export any excess, but will also draw a constant ~40w at all times for an unknown reason
+    # 0: "Don't Sell", 1: "Sell solar"
+    SwitchRWSensor(247, "Solar Export"), 
     SwitchRWSensor(248, "Use Timer", bitmask=1),
 )
 

--- a/src/sunsynk/definitions.py
+++ b/src/sunsynk/definitions.py
@@ -223,8 +223,8 @@ SENSORS += (
         "Load Limit",
         options={0: "Allow Export", 1: "Essentials", 2: "Zero Export"},
     ),
-    # If disabled, does not allow the export of any excess solar. 
-    # If enabled, will export any excess, but will also draw a 
+    # If disabled, does not allow the export of any excess solar.
+    # If enabled, will export any excess, but will also draw a
     # constant ~40w at all times for an unknown reason
     # 0: "Don't Sell", 1: "Sell solar"
     SwitchRWSensor(247, "Solar Export"),

--- a/src/sunsynk/definitions.py
+++ b/src/sunsynk/definitions.py
@@ -225,7 +225,7 @@ SENSORS += (
     ),
     # If disabled, does not allow the export of any excess solar. If enabled, will export any excess, but will also draw a constant ~40w at all times for an unknown reason
     # 0: "Don't Sell", 1: "Sell solar"
-    SwitchRWSensor(247, "Solar Export"), 
+    SwitchRWSensor(247, "Solar Export"),
     SwitchRWSensor(248, "Use Timer", bitmask=1),
 )
 


### PR DESCRIPTION
Allows the enabling / disabling of the ability to sell excess solar. Users may want to control this option, as when enabled, the system is known to draw 40w at all times. The scenario here is to turn it off when solar is not expected to produce, and turn it back on when solar is producing.