### PR TITLE
fix definition selection logic introduced when implementing hv support

### DIFF
--- a/src/ha_addon_sunsynk_multi/sensor_options.py
+++ b/src/ha_addon_sunsynk_multi/sensor_options.py
@@ -110,7 +110,7 @@ def import_definitions() -> None:
         _LOGGER.info("Using three phase sensor definitions.")
         DEFS.all = dict(DEFS3.all)
         DEFS.deprecated = DEFS3.deprecated
-    if OPT.sensor_definitions == "three-phase-hv":
+    elif OPT.sensor_definitions == "three-phase-hv":
         _LOGGER.info("Using three phase HV sensor definitions.")
         DEFS.all = dict(DEFS3HV.all)
         DEFS.deprecated = DEFS3HV.deprecated


### PR DESCRIPTION
I made logic error when implementing 3PH HV support. Now 3PH LV gets both 3PH LV and 1PH definitions applied.
 
Currently:
```
sunsynk-1  | 08:58:17 INFO    Using three phase sensor definitions.
sunsynk-1  | 08:58:17 INFO    Using Single phase sensor definitions.
```
With the patch:
```
sunsynk-1  | 10:11:11 INFO    Using three phase sensor definitions.
```