### PR TITLE
fix hanging when using solarman driver

### DIFF
--- a/hass-addon-sunsynk-multi/Dockerfile
+++ b/hass-addon-sunsynk-multi/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
         mqtt-entity==0.0.4 \
         prettytable==3.8.0 \
         pymodbus[serial]==3.6.4 \
-        pysolarmanv5==3.0.1 \
+        pysolarmanv5==3.0.2 \
         pyyaml==6.0.1 \
         umodbus==1.0.4 \
     && apk del .build-deps

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ umodbus =
 pymodbus =
     pymodbus[serial]==3.6.4
 solarman =
-    pysolarmanv5==3.0.1
+    pysolarmanv5==3.0.2
 tests =
     pytest
     pytest-asyncio


### PR DESCRIPTION
pysolarmanv5 3.0.2 fixes the hanging issue for me.