### PR TITLE
Negative zero export

### DIFF
--- a/src/sunsynk/definitions3ph.py
+++ b/src/sunsynk/definitions3ph.py
@@ -201,7 +201,7 @@ SENSORS += (
     NumberRWSensor(
         103, "Battery low voltage", VOLT, -0.1
     ),  # interesting perhaps not available in menu. default 4500 (45V)
-    NumberRWSensor(104, "System Zero Export power", WATT, -1),
+    NumberRWSensor(104, "System Zero Export power", WATT, -1, min=-500, max=500),
     NumberRWSensor(105, "Battery Equalization Days", "days", -1),
     NumberRWSensor(106, "Battery Equalization Hours", "h", -1),  # 1 = 0.5 hours
     SwitchRWSensor(129, "Generator Charge enabled"),

--- a/src/sunsynk/definitions3phhv.py
+++ b/src/sunsynk/definitions3phhv.py
@@ -116,7 +116,7 @@ SENSORS += (NumberRWSensor(191, "Grid Peak Shaving power", WATT, 10, max=100000)
 
 # Additional optional sensors
 SENSORS += (
-    NumberRWSensor(104, "System Zero Export power", WATT, -10),
+    NumberRWSensor(104, "System Zero Export power", WATT, -10, min=-500, max=500),
     NumberRWSensor(124, "Generator Charge Start Battery SOC", "%"),
     NumberRWSensor(125, "Generator Charge Battery current", AMPS),
     SwitchRWSensor(110, "Parallel Battery 1 and 2"),


### PR DESCRIPTION
Older firmwares on LV inverters and HV inverter firmwares support negative zero export values. Using negative value injects small ammout to network instead of pulling from network.