### PR TITLE
Add multiplatform deployment

### DIFF
--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -7,11 +7,61 @@ on:
   workflow_dispatch: {}
 
 env:
-  REGISTRY_IMAGE: ghcr.io/maslyankov/hass-addon-sunsynk-multi
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi
 
 jobs:
-  build:
+  information:
+    name: Gather add-on information
     runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.information.outputs.architectures }}
+      build: ${{ steps.information.outputs.build }}
+      description: ${{ steps.information.outputs.description }}
+      environment: ${{ steps.release.outputs.environment }}
+      name: ${{ steps.information.outputs.name }}
+      slug: ${{ steps.information.outputs.slug }}
+      target: ${{ steps.information.outputs.target }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4
+      - name: 🚀 Run add-on information
+        id: information
+        uses: frenck/action-addon-information@v1.4
+        with:
+          path: ./hass-addon-sunsynk-multi
+      - name: ℹ️ Gather version and environment
+        id: release
+        run: |
+          sha="${{ github.sha }}"
+          
+          # Default values
+          environment="edge"
+          version="${sha:0:7}"
+      
+          # Check if it's a release event
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            version="${{ github.event.release.tag_name }}"  # Lowercase the tag name
+            version="${version#v}"  # Remove 'v' prefix if present
+            
+            environment="stable"
+            
+            # Set environment to beta if it's a prerelease
+            if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+              environment="beta"
+            fi
+          fi
+      
+          # Output the environment and version
+          echo "environment=${environment}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      
+          # Log the outputs
+          cat "$GITHUB_OUTPUT" >> $GITHUB_STEP_SUMMARY
+  build:
+    name: 👷 Build & Deploy ${{ matrix.platform }} ${{ needs.information.outputs.environment }}/${{ needs.information.outputs.version }}
+    runs-on: ubuntu-latest
+    needs: information
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +122,11 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          # yamllint disable rule:line-length
+          tags: |
+            ${{ env.REGISTRY_IMAGE }}/${{ matrix.platform }}:${{ needs.information.outputs.environment }}
+            ${{ env.REGISTRY_IMAGE }}/${{ matrix.platform }}:${{ steps.meta.outputs.version }}
+          # yamllint enable rule:line-length
           context: ./hass-addon-sunsynk-multi  # Specify the directory containing your Dockerfile
           file: ./hass-addon-sunsynk-multi/Dockerfile  # Specify the Dockerfile path within the context
           platforms: ${{ matrix.platform }}
@@ -102,6 +157,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs:
+      - information
       - build
     steps:
       - name: Download digests
@@ -130,7 +186,9 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY_IMAGE }}:${{ needs.information.outputs.version }} \
+            -t ${{ env.REGISTRY_IMAGE }}:${{ needs.information.outputs.environment }} \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image

--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -144,7 +144,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Prepare artifact name
-        run: echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/\//-/g')" >> $GITHUB_ENV
+        run: echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')" >> $GITHUB_ENV
   
       - name: Upload digest
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -1,0 +1,138 @@
+name: Deploy hass-addon-sunsynk-multi to ghcr.io
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch: {}
+
+env:
+  REGISTRY_IMAGE: ghcr.io/maslyankov/hass-addon-sunsynk-multi
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          # - linux/i386
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4  # Checkout the repository
+
+      - name: Prepare Files for Build
+        run: |
+          mkdir -p hass-addon-sunsynk-multi/sunsynk
+          cp -r src hass-addon-sunsynk-multi/sunsynk/
+          cp setup.* README.md hass-addon-sunsynk-multi/sunsynk/
+
+      - name: Set up the correct base image based on platform
+        run: |
+          case "${{ matrix.platform }}" in
+            linux/amd64)  echo "BUILD_FROM=homeassistant/amd64-base-python:3.11-alpine3.18" >> $GITHUB_ENV ;;
+            linux/arm64)  echo "BUILD_FROM=homeassistant/aarch64-base-python:3.11-alpine3.18" >> $GITHUB_ENV ;;
+            linux/arm/v6) echo "BUILD_FROM=homeassistant/armhf-base-python:3.11-alpine3.18" >> $GITHUB_ENV ;;
+            linux/arm/v7) echo "BUILD_FROM=homeassistant/armv7-base-python:3.11-alpine3.18" >> $GITHUB_ENV ;;
+            linux/i386)   echo "BUILD_FROM=homeassistant/i386-base-python:3.11-alpine3.18" >> $GITHUB_ENV ;;
+          esac
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache  # Cache path
+          key: ${{ runner.os }}-buildx-${{ github.sha }}  # Unique key for cache
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./hass-addon-sunsynk-multi  # Specify the directory containing your Dockerfile
+          file: ./hass-addon-sunsynk-multi/Dockerfile  # Specify the Dockerfile path within the context
+          platforms: ${{ matrix.platform }}
+          cache-from: type=local,src=/tmp/.buildx-cache  # Use cache for build
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max  # Save cache
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            BUILD_FROM=${{ env.BUILD_FROM }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Prepare artifact name
+        run: echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/\//-/g')" >> $GITHUB_ENV
+  
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.SANITIZED_PLATFORM }}  # Use the sanitized platform name
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -118,15 +118,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare sanitized platform name
+        run: |
+          SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')
+          echo "SANITIZED_PLATFORM=${SANITIZED_PLATFORM}" >> $GITHUB_ENV
+          echo "Sanitized platform name: ${SANITIZED_PLATFORM}"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
-          # yamllint disable rule:line-length
           tags: |
-            ${{ env.REGISTRY_IMAGE }}/${{ matrix.platform }}:${{ needs.information.outputs.environment }}
-            ${{ env.REGISTRY_IMAGE }}/${{ matrix.platform }}:${{ steps.meta.outputs.version }}
-          # yamllint enable rule:line-length
+            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.version }}-${{ env.SANITIZED_PLATFORM }}
+            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.environment }}-${{ env.SANITIZED_PLATFORM }}
+            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ env.SANITIZED_PLATFORM }}
+            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.environment }}
           context: ./hass-addon-sunsynk-multi  # Specify the directory containing your Dockerfile
           file: ./hass-addon-sunsynk-multi/Dockerfile  # Specify the Dockerfile path within the context
           platforms: ${{ matrix.platform }}
@@ -143,9 +150,6 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Prepare artifact name
-        run: echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')" >> $GITHUB_ENV
-  
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -70,11 +70,12 @@ jobs:
           - linux/arm/v6
           - linux/arm/v7
           - linux/arm64
-          # - linux/i386
+    outputs:
+      platforms: ${{ steps.collect-platforms.outputs.platforms }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4  # Checkout the repository
-
+        uses: actions/checkout@v4
+      
       - name: Prepare Files for Build
         run: |
           mkdir -p hass-addon-sunsynk-multi/sunsynk
@@ -123,17 +124,18 @@ jobs:
           SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')
           echo "SANITIZED_PLATFORM=${SANITIZED_PLATFORM}" >> $GITHUB_ENV
           echo "Sanitized platform name: ${SANITIZED_PLATFORM}"
+          echo "${SANITIZED_PLATFORM}" >> /tmp/platforms.txt
+
+      - name: Upload platform information
+        uses: actions/upload-artifact@v4
+        with:
+          name: platforms
+          path: /tmp/platforms.txt
 
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.version }}-${{ env.SANITIZED_PLATFORM }}
-            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.environment }}-${{ env.SANITIZED_PLATFORM }}
-            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ env.SANITIZED_PLATFORM }}
-            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/hass-addon-sunsynk-multi:${{ needs.information.outputs.environment }}
           context: ./hass-addon-sunsynk-multi  # Specify the directory containing your Dockerfile
           file: ./hass-addon-sunsynk-multi/Dockerfile  # Specify the Dockerfile path within the context
           platforms: ${{ matrix.platform }}
@@ -158,19 +160,34 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Prepare sanitized platform name
+        id: sanitize-platform
+        run: |
+          echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')" >> $GITHUB_ENV
+          echo "Sanitized platform: $SANITIZED_PLATFORM"
+
+      - name: Collect platforms
+        id: collect-platforms
+        run: |
+          # Get the platforms from the previous matrix job if any
+          platforms="${{ needs.build.outputs.platforms }}"
+          
+          # Append the current sanitized platform
+          platforms="${platforms},${{ env.SANITIZED_PLATFORM }}"
+          
+          # Remove any leading commas
+          platforms="${platforms#,}"
+  
+          # Output the final list of platforms
+          echo "platforms=$platforms" >> $GITHUB_ENV
+          echo "::set-output name=platforms::$platforms"
+
   merge:
     runs-on: ubuntu-latest
     needs:
       - information
       - build
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -187,12 +204,37 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate tags for multi-platform image
+        run: |
+          # Define base tags
+          TAGS=(
+            "-t ${{ env.REGISTRY_IMAGE }}:${{ needs.information.outputs.version }}"
+            "-t ${{ env.REGISTRY_IMAGE }}:${{ needs.information.outputs.environment }}"
+          )
+          
+          # Get the list of platforms from the build job output
+          platforms="${{ needs.build.outputs.platforms }}"
+
+          # Split the platforms and add platform-specific tags
+          IFS=',' read -ra PLATFORM_ARRAY <<< "$platforms"
+          for PLATFORM in "${PLATFORM_ARRAY[@]}"; do
+            TAGS+=("-t ${{ env.REGISTRY_IMAGE }}/${PLATFORM}:${{ needs.information.outputs.version }}")
+            TAGS+=("-t ${{ env.REGISTRY_IMAGE }}/${PLATFORM}:${{ needs.information.outputs.environment }}")
+          done
+          
+          # Join tags into a string
+          TAGS_STRING=$(printf " %s" "${TAGS[@]}")
+          
+          # Export the tags string to the environment for later use
+          echo "TAGS_STRING=${TAGS_STRING}" >> $GITHUB_ENV
+          
+          # Log the generated tags for debugging
+          echo "Generated tags: ${TAGS_STRING}"
+
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY_IMAGE }}:${{ needs.information.outputs.version }} \
-            -t ${{ env.REGISTRY_IMAGE }}:${{ needs.information.outputs.environment }} \
+          docker buildx imagetools create $TAGS_STRING \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image


### PR DESCRIPTION
Making the GitHub Actions workflow build a multi-platform image would make standalone deployments much easier to achieve as you use the same image url for all platforms. This has been tested by myself and you can see the results bellow.

Workflow: https://github.com/maslyankov/sunsynk/actions/workflows/deploy-multi-mp.yml
Resulting image/package: https://github.com/maslyankov/sunsynk/pkgs/container/hass-addon-sunsynk-multi

This change would also require docs changes, but I will get to that if there is interest to merge it.
I am currently using the build image like this, same can be used on all platforms:

 compose.yml
```
services:
  sunsynk-multi:
    image: ghcr.io/maslyankov/hass-addon-sunsynk-multi:main
    restart: unless-stopped
    volumes:
      - ./site_data/sunsynk/options.yaml:/data/options.yaml
    environment:
      MQTT_HOST: mqtt
      MQTT_PORT: 1883
      MQTT_USERNAME: ${MQTT_USER}
      MQTT_PASSWORD: ${MQTT_PASSWORD}
      S6_KEEP_ENV: 1
```
 