### PR TITLE
Fix multi platform build and add docs

### DIFF
--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -70,8 +70,6 @@ jobs:
           - linux/arm/v6
           - linux/arm/v7
           - linux/arm64
-    outputs:
-      platforms: ${{ steps.collect-platforms.outputs.platforms }}
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4
@@ -120,17 +118,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare sanitized platform name
+        id: sanitize-platform
         run: |
-          SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')
+          SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///; s/\///g')
           echo "SANITIZED_PLATFORM=${SANITIZED_PLATFORM}" >> $GITHUB_ENV
           echo "Sanitized platform name: ${SANITIZED_PLATFORM}"
-          echo "${SANITIZED_PLATFORM}" >> /tmp/platforms.txt
-
-      - name: Upload platform information
-        uses: actions/upload-artifact@v4
-        with:
-          name: platforms
-          path: /tmp/platforms.txt
 
       - name: Build and push by digest
         id: build
@@ -160,27 +152,17 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - name: Prepare sanitized platform name
-        id: sanitize-platform
+      - name: Save platform to file
+        id: save-platform
         run: |
-          echo "SANITIZED_PLATFORM=$(echo ${{ matrix.platform }} | sed 's/^linux\///')" >> $GITHUB_ENV
-          echo "Sanitized platform: $SANITIZED_PLATFORM"
-
-      - name: Collect platforms
-        id: collect-platforms
-        run: |
-          # Get the platforms from the previous matrix job if any
-          platforms="${{ needs.build.outputs.platforms }}"
-          
-          # Append the current sanitized platform
-          platforms="${platforms},${{ env.SANITIZED_PLATFORM }}"
-          
-          # Remove any leading commas
-          platforms="${platforms#,}"
+          mkdir -p outputs
+          echo ${{ env.SANITIZED_PLATFORM }} >> outputs/${{ env.SANITIZED_PLATFORM }}.txt
   
-          # Output the final list of platforms
-          echo "platforms=$platforms" >> $GITHUB_ENV
-          echo "::set-output name=platforms::$platforms"
+      - name: Artifact platform file for later
+        uses: actions/upload-artifact@v3
+        with:
+          name: outputs
+          path: outputs/*.txt
 
   merge:
     runs-on: ubuntu-latest
@@ -188,6 +170,13 @@ jobs:
       - information
       - build
     steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -204,6 +193,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Load outputs
+        uses: actions/download-artifact@v3
+        with:
+          name: outputs
+          path: outputs
+
+      - name: Load outputs to variable
+        id: platforms_raw
+        run: |
+          ls outputs
+          # Replace newlines with commas, then remove the trailing comma
+          echo "value=$(cat outputs/*.txt | tr '\n' ',' | sed 's/,$//')" >> "$GITHUB_OUTPUT"
+
       - name: Generate tags for multi-platform image
         run: |
           # Define base tags
@@ -213,7 +215,7 @@ jobs:
           )
           
           # Get the list of platforms from the build job output
-          platforms="${{ needs.build.outputs.platforms }}"
+          platforms="${{ steps.platforms_raw.outputs.value }}"
 
           # Split the platforms and add platform-specific tags
           IFS=',' read -ra PLATFORM_ARRAY <<< "$platforms"
@@ -239,4 +241,11 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          # Inspect the image using the first tag from TAGS_STRING (without the leading '-t ' part)
+          INSPECT_TAG=$(echo "${TAGS_STRING}" | awk '{print $2}')
+          
+          # Log the tag being inspected
+          echo "Inspecting image with tag: $INSPECT_TAG"
+          
+          # Run the inspection
+          docker buildx imagetools inspect $INSPECT_TAG

--- a/.github/workflows/deploy-multi-mp.yml
+++ b/.github/workflows/deploy-multi-mp.yml
@@ -249,3 +249,24 @@ jobs:
           
           # Run the inspection
           docker buildx imagetools inspect $INSPECT_TAG
+
+  publish_addon:
+    name: 🆕 Update addon version to ${{ needs.information.outputs.version }}
+    needs: [information, build, merge]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Point edge to the new ref
+        run: |
+          sed -i 's/version:.*/version: "${{ needs.information.outputs.version }}"/g' hass-addon-sunsynk-edge/config.yaml
+      - name: Point multi to the new ref
+        if: "${{ needs.information.outputs.environment == 'stable'}}"
+        run: |
+          sed -i 's/version:.*/version: "${{ needs.information.outputs.version }}"/g' hass-addon-sunsynk-multi/config.yaml
+      - uses: stefanzweifel/git-auto-commit-action@v5.0.1
+        with:
+          branch: main
+          commit_user_email: kellerza@gmail.com
+          commit_message: Update addon version to ${{ needs.information.outputs.version }} [no ci]

--- a/www/docs/guide/standalone-deployment.md
+++ b/www/docs/guide/standalone-deployment.md
@@ -84,71 +84,51 @@ The repo also contains prebuilt Docker images for Sunsynk Multi. You can see the
 
 ### Docker-Compose examples
 
-#### amd64
+#### amd64 / aarch64 / armv6 / armv7
 
-``` yaml
+```yaml
 services:
   sunsynk-multi:
     restart: unless-stopped
-    image: ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
+    image: ghcr.io/kellerza/hass-addon-sunsynk-multi:stable
     volumes:
       - ${PWD}/options.yaml:/data/options.yaml
 ```
 
-#### aarch64
-
-``` yaml
+```yaml
 services:
   sunsynk-multi:
     restart: unless-stopped
-    image: ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
+    image: ghcr.io/kellerza/hass-addon-sunsynk-multi:stable
     volumes:
       - ${PWD}/options.yaml:/data/options.yaml
-```
-
-#### armv7
-
-``` yaml
-services:
-  sunsynk-multi:
-    restart: unless-stopped
-    image: ghcr.io/kellerza/hass-addon-sunsynk-multi/armv7:stable
-    volumes:
-      - ${PWD}/options.yaml:/data/options.yaml
+    environment:
+      MQTT_HOST: mqtt
+      MQTT_PORT: 1883
+      MQTT_USERNAME: ${MQTT_USER}
+      MQTT_PASSWORD: ${MQTT_PASSWORD}
+      S6_KEEP_ENV: 1
 ```
 
 ### Docker CLI examples
 
 Below are examples using the docker CLI.
 
-> ℹ️ **Note:** Replace ${PWD} with the path to the location of your `options.yaml` file.
+> ℹ️ **Note:** Replace `${PWD}` with the path to the location of your `options.yaml` file.
 
-#### CLI: amd64
+#### CLI: amd64 / aarch64 / armv6 / armv7
 
-``` bash
+```bash
 docker run -d --name sunsynk-multi \
 --restart unless-stopped \
 -v ${PWD}/options.yaml:/data/options.yaml \
-ghcr.io/kellerza/hass-addon-sunsynk-multi/amd64:stable
+ghcr.io/kellerza/hass-addon-sunsynk-multi:stable
 ```
 
-#### CLI: aarch64
+### Important Information on Compatibility
 
-``` bash
-docker run -d --name sunsynk-multi \
---restart unless-stopped \
--v ${PWD}/options.yaml:/data/options.yaml \
-ghcr.io/kellerza/hass-addon-sunsynk-multi/aarch64:stable
-```
+You should use the `ghcr.io/kellerza/hass-addon-sunsynk-multi` image without specifying the platform, as the image is supported for all platforms. However, it is backwards compatible, meaning that even if you use `ghcr.io/kellerza/hass-addon-sunsynk-multi/armv6` on an x86 PC, it will still work. This offers flexibility when pulling images for different platforms.
 
-#### CLI: armv7
-
-``` bash
-docker run -d --name sunsynk-multi \
---restart unless-stopped \
--v ${PWD}/options.yaml:/data/options.yaml \
-ghcr.io/kellerza/hass-addon-sunsynk-multi/armv7:stable
-```
 
 ## Using Environment Variables with Docker Compose
 


### PR DESCRIPTION
### PR Description:

**Fixes and Enhancements:**
- Resolved issues with image tagging across different platforms.
- Streamlined the tagging process to support all platforms while maintaining backwards compatibility.
  
**Documentation Update:**
- Added comprehensive documentation for standalone deployment of the `hass-addon-sunsynk-multi` service using Docker Compose and Docker CLI.
- Provided detailed examples for local Docker builds and pre-built images for various architectures (amd64, aarch64, armv7).
- Documented instructions for running the addon alongside `mbusd` on Raspberry Pi and other hosts without requiring Home Assistant.

**Cleanups:**
- Removed unnecessary steps and streamlined the instructions for easier deployment.

This PR ensures smoother multi-platform support and provides clarity for users setting up the addon in standalone environments.

Example packages: https://github.com/maslyankov?tab=packages&repo_name=sunsynk
Example run: https://github.com/maslyankov/sunsynk/actions/runs/11375051809
Docs: https://github.com/maslyankov/sunsynk/blob/improvement/finish-up-multibase-build-workflow/www/docs/guide/standalone-deployment.md
