### PR TITLE
Sensor options

### DIFF
--- a/hass-addon-sunsynk-multi/Dockerfile.local
+++ b/hass-addon-sunsynk-multi/Dockerfile.local
@@ -1,6 +1,6 @@
 # FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:edge
 # FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:0.7.5
-FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:7a2597f
+FROM ghcr.io/kellerza/hass-addon-sunsynk-multi:7a2597f
 
 # Install sunsynk from local source
 COPY sunsynk sunsynk

--- a/hass-addon-sunsynk-multi/Dockerfile.local
+++ b/hass-addon-sunsynk-multi/Dockerfile.local
@@ -1,5 +1,6 @@
 # FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:edge
-FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:0.7.5
+# FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:0.7.5
+FROM ghcr.io/kellerza/hass-addon-sunsynk-multi/armhf:7a2597f
 
 # Install sunsynk from local source
 COPY sunsynk sunsynk

--- a/src/ha_addon_sunsynk_multi/a_inverter.py
+++ b/src/ha_addon_sunsynk_multi/a_inverter.py
@@ -133,6 +133,12 @@ class AInverter:
             )
         self.log_bold(f"Inverter serial number '****{actual_ser[-4:]}'")
 
+        _LOGGER.info(
+            "Device type: %s, using the %s sensor definitions",
+            self.inv.state[DEFS.device_type],
+            OPT.sensor_definitions,
+        )
+
         # Initial read for all sensors
         sensors = list(SOPT)
         _LOGGER.info("Reading all sensors %s", ", ".join(s.name for s in sensors))

--- a/src/ha_addon_sunsynk_multi/a_inverter.py
+++ b/src/ha_addon_sunsynk_multi/a_inverter.py
@@ -117,11 +117,10 @@ class AInverter:
                 f"Could not connect to {self.inv.port}: {exc}"
             ) from exc
 
-        _LOGGER.info(
-            "Reading startup sensors %s", ", ".join(s.name for s in SOPT.startup)
-        )
+        sensors = list(SOPT.startup)
+        _LOGGER.info("Reading startup sensors %s", ", ".join(s.name for s in sensors))
 
-        if not await self.read_sensors_retry(sensors=list(SOPT.startup)):
+        if not await self.read_sensors_retry(sensors=sensors):
             raise ConnectionError(
                 f"No response on the Modbus interface {self.inv.port}, "
                 "see https://kellerza.github.io/sunsynk/guide/fault-finding"
@@ -133,6 +132,11 @@ class AInverter:
                 f"Serial number mismatch. Expected {expected_ser}, got {actual_ser}"
             )
         self.log_bold(f"Inverter serial number '****{actual_ser[-4:]}'")
+
+        # Initial read for all sensors
+        sensors = list(SOPT)
+        _LOGGER.info("Reading all sensors %s", ", ".join(s.name for s in sensors))
+        await self.read_sensors(sensors=sensors)
 
     @property
     def rated_power(self) -> float:

--- a/src/ha_addon_sunsynk_multi/sensor_options.py
+++ b/src/ha_addon_sunsynk_multi/sensor_options.py
@@ -106,6 +106,12 @@ class SensorOptions(dict[Sensor, SensorOption]):
                 ", ".join(hidden),
             )
 
+        # Add Affects
+        for sen in self:
+            if isinstance(sen, RWSensor):
+                for dep in sen.dependencies:
+                    self[dep].affects.add(sen)
+
 
 def import_definitions() -> None:
     """Load definitions according to options."""

--- a/src/ha_addon_sunsynk_multi/sensor_options.py
+++ b/src/ha_addon_sunsynk_multi/sensor_options.py
@@ -71,7 +71,7 @@ class SensorOptions(dict[Sensor, SensorOption]):
             import_definitions()
         self.clear()
 
-        self.startup = {DEFS.device_type, DEFS.rated_power, DEFS.serial}
+        self.startup = {DEFS.device_type, DEFS.serial}
         sensors_all = list(get_sensors(target=self, names=OPT.sensors))
         sensors_1st = list(get_sensors(target=self, names=OPT.sensors_first_inverter))
 

--- a/src/sunsynk/definitions/__init__.py
+++ b/src/sunsynk/definitions/__init__.py
@@ -1,6 +1,6 @@
 """Sensor definitions."""
 
-from sunsynk.sensors import EnumSensor
+from sunsynk.sensors import EnumSensor, SerialSensor
 
 DEVICE_TYPE = EnumSensor(
     0,
@@ -13,3 +13,5 @@ DEVICE_TYPE = EnumSensor(
         6: "High voltage three phase hybrid",
     },
 )
+
+SERIAL_SENSOR = SerialSensor((3, 4, 5, 6, 7), "Serial")

--- a/src/sunsynk/definitions/single_phase.py
+++ b/src/sunsynk/definitions/single_phase.py
@@ -1,7 +1,7 @@
 """Sunsynk 5kW&8kW hybrid inverter sensor definitions."""
 
 from sunsynk import AMPS, CELSIUS, KWH, VOLT, WATT
-from sunsynk.definitions import DEVICE_TYPE
+from sunsynk.definitions import DEVICE_TYPE, SERIAL_SENSOR
 from sunsynk.rwsensors import (
     NumberRWSensor,
     SelectRWSensor,
@@ -17,7 +17,6 @@ from sunsynk.sensors import (
     SDStatusSensor,
     Sensor,
     SensorDefinitions,
-    SerialSensor,
     TempSensor,
 )
 
@@ -153,7 +152,7 @@ RATED_POWER = Sensor((16, 17), "Rated power", WATT, 0.1)
 SENSORS += (
     DEVICE_TYPE,
     RATED_POWER,
-    SerialSensor((3, 4, 5, 6, 7), "Serial"),
+    SERIAL_SENSOR,
     FaultSensor((103, 104, 105, 106), "Fault"),
     InverterStateSensor(59, "Overall state"),
     SDStatusSensor(92, "SD Status", ""),  # type: ignore

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -1,7 +1,7 @@
 """Sunsynk 5kW&8kW hybrid 3-phase inverter sensor definitions."""
 
 from sunsynk import AMPS, CELSIUS, KWH, VOLT, WATT
-from sunsynk.definitions import DEVICE_TYPE
+from sunsynk.definitions import DEVICE_TYPE, SERIAL_SENSOR
 from sunsynk.rwsensors import (
     NumberRWSensor,
     SelectRWSensor,
@@ -18,7 +18,6 @@ from sunsynk.sensors import (
     SDStatusSensor,
     Sensor,
     SensorDefinitions,
-    SerialSensor,
     TempSensor,
 )
 
@@ -172,7 +171,7 @@ SENSORS += (
     FaultSensor((555, 556, 557, 558), "Fault"),
     InverterStateSensor(500, "Overall state"),
     SDStatusSensor(0, "SD Status", ""),  # type: ignore        # 3 Phase does not have SD Card but crashes when removed
-    SerialSensor((3, 4, 5, 6, 7), "Serial"),
+    SERIAL_SENSOR,
     TempSensor(540, "DC transformer temperature", CELSIUS, 0.1),
     TempSensor(541, "Radiator temperature", CELSIUS, 0.1),
     BinarySensor(552, "Grid Connected", bitmask=1 << 2),

--- a/src/sunsynk/definitions/three_phase_hv.py
+++ b/src/sunsynk/definitions/three_phase_hv.py
@@ -12,9 +12,7 @@ from sunsynk.sensors import (
     EnumSensor,
     HVFaultSensor,
     MathSensor,
-    SDStatusSensor,
     Sensor,
-    SerialSensor,
     TempSensor,
 )
 
@@ -84,8 +82,7 @@ SENSORS += (
         options={0: "No Warning", 1 << 15: "Warning"},
         bitmask=1 << 15,
     ),
-    SDStatusSensor(0, "SD Status", ""),  # type: ignore
-    SerialSensor((3, 4, 5, 6, 7), "Serial"),
+    # SDStatusSensor(0, "SD Status", ""),  # type: ignore
     BinarySensor(552, "Grid Connected", bitmask=1 << 2),
 )
 

--- a/src/sunsynk/sensors.py
+++ b/src/sunsynk/sensors.py
@@ -95,6 +95,11 @@ class SensorDefinitions:
     """map of 'old_name': 'new_name'"""
 
     @property
+    def device_type(self) -> Sensor:
+        """Get the device type."""
+        return self.all["device_type"]
+
+    @property
     def serial(self) -> Sensor:
         """Get the serial sensor."""
         return self.all["serial"]

--- a/src/tests/ha_addon_sunsynk_multi/test_sensor_callback.py
+++ b/src/tests/ha_addon_sunsynk_multi/test_sensor_callback.py
@@ -98,9 +98,11 @@ TEST1 = (
     SensorOption(
         sensor=Sensor(1, name="test", unit="kWh"),
         schedule=Schedule(read_every=1, report_every=10),
+        visible=True,
     ),
     SensorOption(
         sensor=Sensor(2, name="test2", unit="kWh"),
         schedule=Schedule(read_every=1, report_every=20),
+        visible=True,
     ),
 )

--- a/src/tests/ha_addon_sunsynk_multi/test_sensor_options.py
+++ b/src/tests/ha_addon_sunsynk_multi/test_sensor_options.py
@@ -10,31 +10,25 @@ _LOGGER = logging.getLogger(__name__)
 def test_opt1() -> None:
     """Sensors."""
     SOPT.init_sensors()
-    assert sorted(s.id for s in SOPT.startup) == ["rated_power", "serial"]
-    assert sorted(s.id for s in SOPT) == ["rated_power", "serial"]
+    assert sorted(s.id for s in SOPT.startup) == ["device_type", "serial"]
+    assert sorted(s.id for s in SOPT) == ["device_type", "serial"]
 
     OPT.sensors = ["prog1_time"]
     SOPT.init_sensors()
     assert sorted(s.id for s in SOPT.startup) == [
+        "device_type",
+        "serial",
+    ]
+    assert sorted(s.id for s in SOPT) == [
+        "device_type",
         "prog1_time",
         "prog2_time",
         "prog3_time",
         "prog4_time",
         "prog5_time",
         "prog6_time",
-        "rated_power",
         "serial",
     ]
-    assert sorted(s.id for s in SOPT) == [
+    assert sorted(s.id for s in SOPT if SOPT[s].visible) == [
         "prog1_time",
-        "prog2_time",
-        "prog6_time",
-        "rated_power",
-        "serial",
     ]
-    # assert SOPT.filter_str == {
-    #     "prog1_time": "round_robin",
-    #     "prog2_time": "round_robin",
-    #     "prog6_time": "round_robin",
-    # }
-    # assert SOPT["prog1_time"].visible

--- a/src/tests/ha_addon_sunsynk_multi/test_sensor_options.py
+++ b/src/tests/ha_addon_sunsynk_multi/test_sensor_options.py
@@ -14,6 +14,7 @@ def test_opt1() -> None:
     assert sorted(s.id for s in SOPT) == ["device_type", "serial"]
 
     OPT.sensors = ["prog1_time"]
+    OPT.sensors_first_inverter = []
     SOPT.init_sensors()
     assert sorted(s.id for s in SOPT.startup) == [
         "device_type",
@@ -32,3 +33,58 @@ def test_opt1() -> None:
     assert sorted(s.id for s in SOPT if SOPT[s].visible) == [
         "prog1_time",
     ]
+
+
+def test_opt_1st() -> None:
+    """Sensors."""
+    OPT.sensors = ["serial"]
+    OPT.sensors_first_inverter = ["prog1_time", "device_type"]
+    SOPT.init_sensors()
+
+    assert sorted(s.id for s in SOPT.startup) == [
+        "device_type",
+        "serial",
+    ]
+    assert sorted(s.id for s in SOPT) == [
+        "device_type",
+        "prog1_time",
+        "prog2_time",
+        "prog3_time",
+        "prog4_time",
+        "prog5_time",
+        "prog6_time",
+        "serial",
+    ]
+    assert sorted(s.id for s in SOPT if SOPT[s].visible) == [
+        "device_type",
+        "prog1_time",
+        "serial",
+    ]
+    assert sorted(s.id for s in SOPT if SOPT[s].first) == [
+        "prog1_time",
+        "prog2_time",
+        "prog3_time",
+        "prog4_time",
+        "prog5_time",
+        "prog6_time",
+    ]
+
+
+def test_opt_1st_visible() -> None:
+    """Sensors."""
+    OPT.sensors = []
+    OPT.sensors_first_inverter = ["device_type"]
+    SOPT.init_sensors()
+
+    assert sorted(s.id for s in SOPT.startup) == [
+        "device_type",
+        "serial",
+    ]
+    assert sorted(s.id for s in SOPT) == [
+        "device_type",
+        "serial",
+    ]
+    assert sorted(s.id for s in SOPT if SOPT[s].visible) == [
+        "device_type",
+    ]
+    assert sorted(s.id for s in SOPT if SOPT[s].first) == []

--- a/src/tests/ha_addon_sunsynk_multi/test_state.py
+++ b/src/tests/ha_addon_sunsynk_multi/test_state.py
@@ -20,13 +20,15 @@ def test_create_entity(mqtt_device: Device, ist: AInverter) -> None:
     STATE.append(ist)
 
     st = ASensor(
-        opt=SensorOption(sensor=Sensor(1, "one", "W"), schedule=NOSCHEDULE),
+        opt=SensorOption(
+            sensor=Sensor(1, "one", "W"), schedule=NOSCHEDULE, visible=True
+        ),
     )
 
     assert st.name == "one"
 
     # Create the mqtt entity
-    ent: Entity = st.create_entity(dev=mqtt_device, ist=ist)
+    ent: Entity = st.create_entity(mqtt_device, ist=ist)
     entd: dict = ent.asdict
     assert entd == {
         "device": {"identifiers": ["888"]},
@@ -49,7 +51,11 @@ def test_create_entity2(mqtt_device: Device, ist: AInverter) -> None:
 
     STATE.append(ist)
 
-    st = ASensor(opt=SensorOption(sensor=Sensor(1, nme, "kWh"), schedule=NOSCHEDULE))
+    st = ASensor(
+        opt=SensorOption(
+            sensor=Sensor(1, nme, "kWh"), schedule=NOSCHEDULE, visible=True
+        )
+    )
 
     # Create the mqtt entity
     ent: Entity = st.create_entity(mqtt_device, ist=ist)


### PR DESCRIPTION
Continue on #377 & hopefully fixing #374

There are only a single set of sensor options. So, the order that we add these seem important. Deps can be visible if configured on all/1st inverter.

Startup sensors are used to read limited info from the inverter and make sure that the wiring/configuration is correct. By far the most issues on the repo is related to connectivity, so don't want to change this.
  - In line with #377 - the addon now reads all sensors after the serial number is verified

