### PR TITLE
Deye 3phase power switch renamed to Inverter enabled

### DIFF
--- a/src/sunsynk/definitions/single_phase.py
+++ b/src/sunsynk/definitions/single_phase.py
@@ -164,7 +164,7 @@ SENSORS += (
 # Settings
 ###########
 SENSORS += (
-    SwitchRWSensor(43, "Inverter Power", on=1),  # 0=off, 1=on
+    SwitchRWSensor(43, "Inverter enabled", on=1),  # 0=off, 1=on
     Sensor(200, "Control Mode"),
     SwitchRWSensor(232, "Grid Charge enabled", "", bitmask=1),
     SelectRWSensor(

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -199,7 +199,7 @@ SENSORS += (
 # Settings
 ###########
 SENSORS += (
-    SwitchRWSensor(80, "Inverter Power", on=1),  # 0=off, 1=on
+    SwitchRWSensor(80, "Inverter enabled", on=1),  # 0=off, 1=on
     NumberRWSensor(128, "Grid Charge Battery current", AMPS, max=240),
     NumberRWSensor(127, "Grid Charge Start Battery SOC", "%"),
     SwitchRWSensor(130, "Grid Charge enabled", on=1),


### PR DESCRIPTION
New name changed from Switch "Inverter Power" to "Inverter enabled" to avoid override. 