### PR TITLE
Enhance helper functions for register value conversions

### DIFF
--- a/src/sunsynk/helpers.py
+++ b/src/sunsynk/helpers.py
@@ -26,9 +26,15 @@ def pack_value(value: int, bits: int = 16, signed: bool = True) -> RegType:
         For 32-bit: tuple of (low, high) register values
     """
     if bits == 16:
+        if not signed and value < 0:
+            # Convert negative value to two's complement for unsigned
+            value = value + (1 << 16)
         fmt = 'h' if signed else 'H'
         return struct.unpack('H', struct.pack(fmt, value))
     if bits == 32:
+        if not signed and value < 0:
+            # Convert negative value to two's complement for unsigned
+            value = value + (1 << 32)
         fmt = 'i' if signed else 'I'
         return struct.unpack('2H', struct.pack(fmt, value))
     raise ValueError(f"Unsupported number of bits: {bits}")

--- a/src/sunsynk/helpers.py
+++ b/src/sunsynk/helpers.py
@@ -13,7 +13,7 @@ RegType = tuple[int, ...]
 NumType = float | int
 
 
-def pack_value(value: int, bits: int = 16, signed: bool = True) -> int | tuple[int, int]:
+def pack_value(value: int, bits: int = 16, signed: bool = True) -> RegType:
     """Pack a value into register format.
     
     Args:
@@ -27,7 +27,7 @@ def pack_value(value: int, bits: int = 16, signed: bool = True) -> int | tuple[i
     """
     if bits == 16:
         fmt = 'h' if signed else 'H'
-        return struct.unpack('H', struct.pack(fmt, value))[0]
+        return struct.unpack('H', struct.pack(fmt, value))
     if bits == 32:
         fmt = 'i' if signed else 'I'
         return struct.unpack('2H', struct.pack(fmt, value))
@@ -102,6 +102,11 @@ def hex_str(regs: RegType, address: RegType | None = None) -> str:
     return f"{{{' '.join(res)}}}"
 
 
+def patch_bitmask(value: int, patch: int, bitmask: int) -> int:
+    """Combine bitmask values."""
+    return (patch & bitmask) + (value & (0xFFFF - bitmask))
+
+
 class SSTime:
     """Deals with inverter time format conversion complexities."""
 
@@ -151,8 +156,3 @@ class SSTime:
             self.minutes = int(hours) * 60 + int(minutes)
         except ValueError:
             _LOGGER.warning("Invalid time string: %s (expected hh:mm)", value)
-
-
-def patch_bitmask(value: int, patch: int, bitmask: int) -> int:
-    """Combine bitmask values."""
-    return (patch & bitmask) + (value & (0xFFFF - bitmask))

--- a/src/sunsynk/helpers.py
+++ b/src/sunsynk/helpers.py
@@ -26,15 +26,9 @@ def pack_value(value: int, bits: int = 16, signed: bool = True) -> RegType:
         For 32-bit: tuple of (low, high) register values
     """
     if bits == 16:
-        if not signed and value < 0:
-            # Convert negative value to two's complement for unsigned
-            value = value + (1 << 16)
         fmt = 'h' if signed else 'H'
         return struct.unpack('H', struct.pack(fmt, value))
     if bits == 32:
-        if not signed and value < 0:
-            # Convert negative value to two's complement for unsigned
-            value = value + (1 << 32)
         fmt = 'i' if signed else 'I'
         return struct.unpack('2H', struct.pack(fmt, value))
     raise ValueError(f"Unsupported number of bits: {bits}")

--- a/src/sunsynk/helpers.py
+++ b/src/sunsynk/helpers.py
@@ -2,7 +2,7 @@
 
 import logging
 import math
-from typing import Any, Tuple
+from typing import Any
 import struct
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/sunsynk/rwsensors.py
+++ b/src/sunsynk/rwsensors.py
@@ -82,12 +82,7 @@ class NumberRWSensor(RWSensor):
         maxv = resolve_num(resolve, self.max, 100)
         val = int(max(minv, min(maxv, fval)) / abs(self.factor))
         
-        if len(self.address) == 1:
-            return self.reg(pack_value(val, bits=16, signed=self.factor < 0))
-        if len(self.address) == 2:
-            low, high = pack_value(val, bits=32, signed=self.factor < 0)  # type: ignore
-            return self.reg(low, high)
-        raise NotImplementedError(f"Address length not supported: {self.address}")
+        return self.reg(*pack_value(val, bits=len(self.addrees)*16, signed=self.factor < 0))
 
 
 @attrs.define(slots=True, eq=False)

--- a/src/sunsynk/rwsensors.py
+++ b/src/sunsynk/rwsensors.py
@@ -81,8 +81,7 @@ class NumberRWSensor(RWSensor):
         minv = resolve_num(resolve, self.min, 0)
         maxv = resolve_num(resolve, self.max, 100)
         val = int(max(minv, min(maxv, fval)) / abs(self.factor))
-        
-        return self.reg(*pack_value(val, bits=len(self.addrees)*16, signed=self.factor < 0))
+        return self.reg(*pack_value(val, bits=len(self.address)*16, signed=self.factor < 0))
 
 
 @attrs.define(slots=True, eq=False)

--- a/src/sunsynk/rwsensors.py
+++ b/src/sunsynk/rwsensors.py
@@ -77,6 +77,8 @@ class NumberRWSensor(RWSensor):
 
     def value_to_reg(self, value: ValType, resolve: ResolveType) -> RegType:
         """Get the reg value from a display value."""
+        if not self.address:
+            raise NotImplementedError("Cannot write to a sensor with no address")
         fval = float(value)  # type:ignore
         minv = resolve_num(resolve, self.min, 0)
         maxv = resolve_num(resolve, self.max, 100)
@@ -180,6 +182,12 @@ class SwitchRWSensor(RWSensor):
 class SystemTimeRWSensor(RWSensor):
     """Read & write time sensor."""
 
+    def __attrs_post_init__(self) -> None:
+        """Run post init."""
+        super().__attrs_post_init__()
+        if len(self.address) != 3:
+            raise ValueError("SystemTimeRWSensor requires exactly 3 registers")
+
     def value_to_reg(self, value: ValType, resolve: ResolveType) -> RegType:
         """Get the reg value from a display value."""
         # pylint: disable=invalid-name
@@ -245,6 +253,8 @@ class TimeRWSensor(RWSensor):
 
     def value_to_reg(self, value: ValType, resolve: ResolveType) -> RegType:
         """Get the reg value from a display value."""
+        if not self.address:
+            raise NotImplementedError("Cannot write to a sensor with no address")
         return self.reg(SSTime(string=str(value)).reg_value)
 
     @staticmethod

--- a/src/sunsynk/sensors.py
+++ b/src/sunsynk/sensors.py
@@ -7,7 +7,6 @@ import logging
 import attrs
 
 from sunsynk.helpers import (
-    NumType,
     RegType,
     ValType,
     ensure_tuple,

--- a/src/sunsynk/sensors.py
+++ b/src/sunsynk/sensors.py
@@ -136,7 +136,7 @@ class MathSensor(Sensor):
 
     def reg_to_value(self, regs: RegType) -> ValType:
         """Calculate the math value."""
-        val = int_round(sum(signed(i) * s for i, s in zip(regs, self.factors)))
+        val = int_round(sum(unpack_value((i,), signed=True) * s for i, s in zip(regs, self.factors)))
         if self.absolute and val < 0:
             val = -val
         if self.no_negative and val < 0:

--- a/src/sunsynk/sensors.py
+++ b/src/sunsynk/sensors.py
@@ -38,7 +38,7 @@ class Sensor:
         """Return the value from the registers."""
         regs = self.masked(regs)
         val = unpack_value(regs, signed=self.factor < 0)
-        val = int_round(val * abs(self.factor))
+        val = int_round(float(val) * abs(self.factor))
         _LOGGER.debug("%s=%s%s %s", self.id, val, self.unit, regs)
         return val
 

--- a/src/sunsynk/sensors.py
+++ b/src/sunsynk/sensors.py
@@ -12,9 +12,8 @@ from sunsynk.helpers import (
     ValType,
     ensure_tuple,
     int_round,
-    signed,
     slug,
-    make_32bit,
+    unpack_value,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,14 +38,7 @@ class Sensor:
     def reg_to_value(self, regs: RegType) -> ValType:
         """Return the value from the registers."""
         regs = self.masked(regs)
-        if len(regs) == 1:
-            val = regs[0]
-            if self.factor < 0:  # Indicates this register is signed
-                val = signed(val, bits=16)
-        elif len(regs) == 2:
-            val = make_32bit(regs[0], regs[1], signed=self.factor < 0)
-        else:
-            raise ValueError(f"Unsupported register length: {len(regs)}")
+        val = unpack_value(regs, signed=self.factor < 0)
         val = int_round(val * abs(self.factor))
         _LOGGER.debug("%s=%s%s %s", self.id, val, self.unit, regs)
         return val

--- a/src/sunsynk/sensors.py
+++ b/src/sunsynk/sensors.py
@@ -9,6 +9,7 @@ import attrs
 from sunsynk.helpers import (
     RegType,
     ValType,
+    NumType,
     ensure_tuple,
     int_round,
     slug,
@@ -37,7 +38,7 @@ class Sensor:
     def reg_to_value(self, regs: RegType) -> ValType:
         """Return the value from the registers."""
         regs = self.masked(regs)
-        val = unpack_value(regs, signed=self.factor < 0)
+        val: NumType = unpack_value(regs, signed=self.factor < 0)
         val = int_round(float(val) * abs(self.factor))
         _LOGGER.debug("%s=%s%s %s", self.id, val, self.unit, regs)
         return val

--- a/src/sunsynk/state.py
+++ b/src/sunsynk/state.py
@@ -7,7 +7,8 @@ from typing import Callable, Generator, Iterable, Iterator, Sequence, cast
 import attr
 
 from sunsynk.rwsensors import RWSensor
-from sunsynk.sensors import BinarySensor, NumType, Sensor, ValType
+from sunsynk.sensors import BinarySensor, Sensor, ValType
+from sunsynk.helpers import NumType
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/tests/sunsynk/test_helpers.py
+++ b/src/tests/sunsynk/test_helpers.py
@@ -55,7 +55,9 @@ def test_signed32bits() -> None:
     """Test 32-bit signed value conversion."""
     assert unpack_value((0xFFFF, 0x7FFF), signed=True) == 0x7FFFFFFF
     assert unpack_value((0xFFFF, 0xFFFF), signed=True) == -1
-    assert unpack_value((0x0000, 0x8000), signed=True) == 0x80000000 - (1 << 32)  # -2147483648
+    assert unpack_value((0x0000, 0x8000), signed=True) == 0x80000000 - (
+        1 << 32
+    )  # -2147483648
 
 
 def test_signeds() -> None:

--- a/src/tests/sunsynk/test_helpers.py
+++ b/src/tests/sunsynk/test_helpers.py
@@ -1,18 +1,17 @@
 """Test helpers."""
 
-import pytest
-
 from sunsynk.helpers import (
     SSTime,
     as_num,
     ensure_tuple,
     hex_str,
     int_round,
-    patch_bitmask,
     pack_value,
+    patch_bitmask,
     unpack_value,
 )
 from sunsynk.sensors import Sensor
+import pytest
 
 
 def test_as_num(caplog: pytest.LogCaptureFixture) -> None:
@@ -109,11 +108,9 @@ def test_pack_unpack() -> None:
     assert pack_value(-1, bits=16, signed=True) == (0xFFFF,)
     assert pack_value(32767, bits=16, signed=True) == (0x7FFF,)
     assert pack_value(65535, bits=16, signed=False) == (0xFFFF,)
-    
     # Test 32-bit values
     assert pack_value(-1, bits=32, signed=True) == (0xFFFF, 0xFFFF)
     assert pack_value(0x7FFFFFFF, bits=32, signed=True) == (0xFFFF, 0x7FFF)
-    
     # Test round-trip
     val = -12345
     assert unpack_value(pack_value(val, bits=16, signed=True), signed=True) == val

--- a/src/tests/sunsynk/test_helpers.py
+++ b/src/tests/sunsynk/test_helpers.py
@@ -9,12 +9,14 @@ from sunsynk.helpers import (
     hex_str,
     int_round,
     patch_bitmask,
-    signed,
+    pack_value,
+    unpack_value,
 )
 from sunsynk.sensors import Sensor
 
 
 def test_as_num(caplog: pytest.LogCaptureFixture) -> None:
+    """Test as_num function."""
     assert as_num(None) == 0
     assert as_num(1.0) == 1.0
     assert as_num(1) == 1
@@ -26,6 +28,7 @@ def test_as_num(caplog: pytest.LogCaptureFixture) -> None:
 
 
 def test_ensure_tuple() -> None:
+    """Test ensure tuple."""
     assert ensure_tuple(1) == (1,)
     assert ensure_tuple((1,)) == (1,)
     assert ensure_tuple((1, 5)) == (1, 5)
@@ -33,23 +36,26 @@ def test_ensure_tuple() -> None:
 
 
 def test_int_round() -> None:
+    """Test int round."""
     res1 = int_round(1.0)
     assert isinstance(res1, int)
     assert res1 == 1
 
 
 def test_signed() -> None:
-    assert signed(0x7FFF) == 0x7FFF
-    assert signed(0xFFFF) == -1
-    assert signed(0) == 0
-    assert signed(32767) == 32767
-    assert signed(32768) == -32768
+    """Test signed value conversion."""
+    assert unpack_value((0x7FFF,), signed=True) == 0x7FFF
+    assert unpack_value((0xFFFF,), signed=True) == -1
+    assert unpack_value((0,), signed=True) == 0
+    assert unpack_value((32767,), signed=True) == 32767
+    assert unpack_value((32768,), signed=True) == -32768
 
 
 def test_signed32bits() -> None:
-    assert signed(0x7FFFFFFF, bits=32) == 0x7FFFFFFF
-    assert signed(0xFFFFFFFF, bits=32) == -1
-    assert signed(0x80000000, bits=32) == 0x80000000 - (1 << 32)
+    """Test 32-bit signed value conversion."""
+    assert unpack_value((0xFFFF, 0x7FFF), signed=True) == 0x7FFFFFFF
+    assert unpack_value((0xFFFF, 0xFFFF), signed=True) == -1
+    assert unpack_value((0x0000, 0x8000), signed=True) == 0x80000000 - (1 << 32)  # -2147483648
 
 
 def test_signeds() -> None:
@@ -66,6 +72,7 @@ def test_signeds() -> None:
 
 
 def test_time() -> None:
+    """Test SSTime class."""
     time = SSTime(minutes=10)
     assert time.str_value == "0:10"
     assert time.reg_value == 10
@@ -96,7 +103,25 @@ def test_time() -> None:
     assert time.minutes == just_before_midnight
 
 
+def test_pack_unpack() -> None:
+    """Test pack_value and unpack_value functions."""
+    # Test 16-bit values
+    assert pack_value(-1, bits=16, signed=True) == (0xFFFF,)
+    assert pack_value(32767, bits=16, signed=True) == (0x7FFF,)
+    assert pack_value(65535, bits=16, signed=False) == (0xFFFF,)
+    
+    # Test 32-bit values
+    assert pack_value(-1, bits=32, signed=True) == (0xFFFF, 0xFFFF)
+    assert pack_value(0x7FFFFFFF, bits=32, signed=True) == (0xFFFF, 0x7FFF)
+    
+    # Test round-trip
+    val = -12345
+    assert unpack_value(pack_value(val, bits=16, signed=True), signed=True) == val
+    assert unpack_value(pack_value(val, bits=32, signed=True), signed=True) == val
+
+
 def test_patch_bitmask() -> None:
+    """Test patch_bitmask function."""
     assert patch_bitmask(2, 1, 1) == 3
     assert patch_bitmask(1, 2, 2) == 3
 

--- a/src/tests/sunsynk/test_helpers.py
+++ b/src/tests/sunsynk/test_helpers.py
@@ -1,5 +1,7 @@
 """Test helpers."""
 
+import struct
+
 import pytest
 
 from sunsynk.helpers import (
@@ -118,6 +120,12 @@ def test_pack_unpack() -> None:
     val = -12345
     assert unpack_value(pack_value(val, bits=16, signed=True), signed=True) == val
     assert unpack_value(pack_value(val, bits=32, signed=True), signed=True) == val
+
+    # Test error cases
+    with pytest.raises(struct.error):
+        pack_value(-1, bits=16, signed=False)
+    with pytest.raises(ValueError):
+        pack_value(1, bits=8)  # Invalid bit length
 
 
 def test_patch_bitmask() -> None:

--- a/src/tests/sunsynk/test_helpers.py
+++ b/src/tests/sunsynk/test_helpers.py
@@ -1,5 +1,7 @@
 """Test helpers."""
 
+import pytest
+
 from sunsynk.helpers import (
     SSTime,
     as_num,
@@ -11,7 +13,6 @@ from sunsynk.helpers import (
     unpack_value,
 )
 from sunsynk.sensors import Sensor
-import pytest
 
 
 def test_as_num(caplog: pytest.LogCaptureFixture) -> None:

--- a/src/tests/sunsynk/test_rwsensors.py
+++ b/src/tests/sunsynk/test_rwsensors.py
@@ -94,6 +94,7 @@ def test_number_rw(state: InverterState) -> None:
 
     # writing negative values (when allowed by min)
     s.min = -10
+    s.factor = -1  # indicate signed values
     assert s.value_to_reg(-1, state.get) == (65535,)
 
     s = NumberRWSensor(1, "s2", factor=0.01)


### PR DESCRIPTION
- Added `make_32bit` to convert two 16-bit values into a 32-bit integer.
- Introduced `split_to_16bit` to split a 32-bit integer into two 16-bit values.
- Updated `signed` function to handle struct packing for signed integers.
- Modified `NumberRWSensor` to utilize `split_to_16bit` for handling two 16-bit registers.
- Refactored `reg_to_value` in `Sensor` class to use `make_32bit` for combining register values.

Related PR & issues that arised from it:
- https://github.com/kellerza/sunsynk/pull/391#issuecomment-2599665488
- https://github.com/kellerza/sunsynk/pull/391#issuecomment-2599698838
- https://github.com/kellerza/sunsynk/issues/398

## Why?

Using struct for handling signed integers (especially when merging registers) is better for several key reasons:

1. **Proper Two's Complement Handling**:
   - Struct automatically handles two's complement representation for signed numbers
   - Direct bit manipulation might miss the sign bit handling, leading to incorrect negative values

2. **Platform Independence**:
   ```python
   # Using struct (safe)
   import struct
   value = struct.unpack('>i', bytes([0xFF, 0xFF, 0x80, 0x00]))[0]  # Correctly handles -32768
   
   # Direct bit manipulation (risky)
   value = (register1 << 16) | register2  # Might not handle negative numbers correctly
   ```

3. **Endianness Handling**:
   - Struct allows explicit specification of byte order (big-endian '>' or little-endian '<')
   - Direct bit manipulation requires manual handling of endianness

4. **Type Safety**:
   - Struct enforces proper data type conversion
   - Helps prevent overflow issues and undefined behavior

5. **Maintainability**:
   - Code intent is clearer with struct
   - Less prone to bugs when dealing with different register sizes or signed/unsigned conversions

6. **Standard Library Solution**:
   - Well-tested and documented
   - Consistent behavior across Python versions and platforms

The small performance overhead of using struct is usually worth the reliability and clarity it provides when handling signed integers.