### PR TITLE
Update single_phase.py

### DIFF
--- a/src/sunsynk/definitions/single_phase.py
+++ b/src/sunsynk/definitions/single_phase.py
@@ -311,9 +311,9 @@ SENSORS += (
 #############
 # Inverter settings
 #############
-SENSORS += NumberRWSensor(230, "Grid Charge Battery current", AMPS, min=0, max=185)
-SENSORS += NumberRWSensor(210, "Battery Max Charge current", AMPS, min=0, max=185)
-SENSORS += NumberRWSensor(211, "Battery Max Discharge current", AMPS, min=0, max=185)
+SENSORS += NumberRWSensor(230, "Grid Charge Battery current", AMPS, min=0, max=290)
+SENSORS += NumberRWSensor(210, "Battery Max Charge current", AMPS, min=0, max=290)
+SENSORS += NumberRWSensor(211, "Battery Max Discharge current", AMPS, min=0, max=290)
 
 
 #############

--- a/src/sunsynk/definitions/single_phase.py
+++ b/src/sunsynk/definitions/single_phase.py
@@ -311,7 +311,7 @@ SENSORS += (
 #############
 # Inverter settings
 #############
-SENSORS += NumberRWSensor(230, "Grid Charge Battery current", AMPS, min=0, max=290)
+SENSORS += NumberRWSensor(230, "Grid Charge Battery current", AMPS, min=0, max=140)
 SENSORS += NumberRWSensor(210, "Battery Max Charge current", AMPS, min=0, max=290)
 SENSORS += NumberRWSensor(211, "Battery Max Discharge current", AMPS, min=0, max=290)
 


### PR DESCRIPTION
change max charge/discharge current to 290A to accommodate the 16KW Deye single phase 

I'd much rather propose ( not sure if possible)
Have a different inverter selection in configuration or;
if sensor.rated power=x then set charge amps to Y
else if sensor.rated power= a then set charge amps to B etc.