### PR TITLE
Bugfix/values spikes

### DIFF
--- a/hass-addon-sunsynk-edge/config.yaml
+++ b/hass-addon-sunsynk-edge/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk/Deye Inverter Add-on (edge/dev)
-version: "47b7ae7"
+version: "3743f52"
 image: ghcr.io/kellerza/hass-addon-sunsynk-multi
 slug: hass-addon-sunsynk-edge
 description: Add-on for a Sunsynk/Deye branded Inverter

--- a/hass-addon-sunsynk-edge/config.yaml
+++ b/hass-addon-sunsynk-edge/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk/Deye Inverter Add-on (edge/dev)
-version: "e6c5d80"
+version: "a664930"
 image: ghcr.io/kellerza/hass-addon-sunsynk-multi
 slug: hass-addon-sunsynk-edge
 description: Add-on for a Sunsynk/Deye branded Inverter

--- a/hass-addon-sunsynk-edge/config.yaml
+++ b/hass-addon-sunsynk-edge/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk/Deye Inverter Add-on (edge/dev)
-version: "3743f52"
+version: "c116115"
 image: ghcr.io/kellerza/hass-addon-sunsynk-multi
 slug: hass-addon-sunsynk-edge
 description: Add-on for a Sunsynk/Deye branded Inverter

--- a/hass-addon-sunsynk-edge/config.yaml
+++ b/hass-addon-sunsynk-edge/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Sunsynk/Deye Inverter Add-on (edge/dev)
-version: "a664930"
+version: "47b7ae7"
 image: ghcr.io/kellerza/hass-addon-sunsynk-multi
 slug: hass-addon-sunsynk-edge
 description: Add-on for a Sunsynk/Deye branded Inverter

--- a/src/tests/sunsynk/test_solarmansunsynk.py
+++ b/src/tests/sunsynk/test_solarmansunsynk.py
@@ -1,5 +1,6 @@
 """Solarman Sunsynk"""
 
+import asyncio
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -121,3 +122,99 @@ async def test_uss_sensor(mock_disconnect: AsyncMock, mock_connect: AsyncMock) -
     assert not mock_client.write_multiple_holding_registers.called
     await ss.write_register(address=1, value=2)
     assert mock_client.write_multiple_holding_registers.called
+
+
+@pytest.mark.asyncio
+async def test_validate_packet_invalid_start_stop() -> None:
+    """Test packet validation with invalid start/stop bytes."""
+    ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
+    
+    # Test invalid start byte
+    invalid_packet = bytes([0x00]) + bytes([0] * 20) + bytes([0x15])
+    assert not ss.validate_packet(invalid_packet, 2)
+    
+    # Test invalid end byte
+    invalid_packet = bytes([0xA5]) + bytes([0] * 20) + bytes([0x00])
+    assert not ss.validate_packet(invalid_packet, 2)
+
+
+@pytest.mark.asyncio
+async def test_validate_packet_invalid_sequence() -> None:
+    """Test packet validation with invalid sequence number."""
+    ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
+    ss.current_sequence_number = 0x42
+    
+    # Create packet with wrong sequence number
+    invalid_packet = bytes([0xA5, 0, 0, 0, 0, 0x43]) + bytes([0] * 15) + bytes([0x15])
+    assert not ss.validate_packet(invalid_packet, 2)
+
+
+@pytest.mark.asyncio
+async def test_validate_packet_invalid_crc() -> None:
+    """Test packet validation with invalid CRC."""
+    ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
+    ss.current_sequence_number = 0x42
+    
+    # Create packet with invalid CRC
+    modbus_frame = bytes([1, 3, 4, 0, 1, 0, 2, 0, 0])  # Invalid CRC at end
+    packet = bytes([0xA5, 0, 0, 0, 0, 0x42]) + bytes([0] * 6) + modbus_frame + bytes([0x15])
+    assert not ss.validate_packet(packet, 2)
+
+
+@pytest.mark.asyncio
+async def test_validate_packet_invalid_length() -> None:
+    """Test packet validation with wrong number of registers."""
+    ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
+    ss.current_sequence_number = 0x42
+    
+    # Create valid Modbus frame but request wrong length
+    modbus_frame = bytes([1, 3, 4, 0, 1, 0, 2])
+    crc = calculate_modbus_crc(modbus_frame)
+    modbus_frame_with_crc = modbus_frame + bytes([crc & 0xFF, crc >> 8])
+    packet = bytes([0xA5, 0, 0, 0, 0, 0x42]) + bytes([0] * 6) + modbus_frame_with_crc + bytes([0x15])
+    
+    # Test with wrong expected length
+    assert not ss.validate_packet(packet, 3)  # Expect 3 registers but only 2 in frame
+
+
+@pytest.mark.asyncio
+@patch("sunsynk.solarmansunsynk.PySolarmanV5Async")
+async def test_connect_disconnect(mock_pysolarman: AsyncMock) -> None:
+    """Test connection and disconnection scenarios."""
+    ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
+    
+    # Test connect when already connected
+    ss.client = AsyncMock()
+    await ss.connect()
+    assert not mock_pysolarman.called
+    
+    # Test disconnect when not connected
+    ss.client = None
+    await ss.disconnect()
+    
+    # Test disconnect with AttributeError
+    mock_client = AsyncMock()
+    mock_client.disconnect.side_effect = AttributeError()
+    ss.client = mock_client
+    await ss.disconnect()
+    assert ss.client is None
+
+
+@pytest.mark.asyncio
+async def test_write_register_errors() -> None:
+    """Test write_register error handling."""
+    ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
+    mock_client = AsyncMock()
+    ss.client = mock_client
+    
+    # Test timeout error
+    mock_client.write_multiple_holding_registers.side_effect = asyncio.TimeoutError()
+    result = await ss.write_register(address=1, value=2)
+    assert not result
+    assert ss.timeouts == 1
+    
+    # Test general exception
+    mock_client.write_multiple_holding_registers.side_effect = Exception("Test error")
+    result = await ss.write_register(address=1, value=2)
+    assert not result
+    assert ss.timeouts == 2

--- a/src/tests/sunsynk/test_solarmansunsynk.py
+++ b/src/tests/sunsynk/test_solarmansunsynk.py
@@ -157,7 +157,9 @@ async def test_validate_packet_invalid_crc() -> None:
 
     # Create packet with invalid CRC
     modbus_frame = bytes([1, 3, 4, 0, 1, 0, 2, 0, 0])  # Invalid CRC at end
-    packet = bytes([0xA5, 0, 0, 0, 0, 0x42]) + bytes([0] * 6) + modbus_frame + bytes([0x15])
+    packet = (
+        bytes([0xA5, 0, 0, 0, 0, 0x42]) + bytes([0] * 6) + modbus_frame + bytes([0x15])
+    )
     assert not ss.validate_packet(packet, 2)
 
 
@@ -171,7 +173,12 @@ async def test_validate_packet_invalid_length() -> None:
     modbus_frame = bytes([1, 3, 4, 0, 1, 0, 2])
     crc = calculate_modbus_crc(modbus_frame)
     modbus_frame_with_crc = modbus_frame + bytes([crc & 0xFF, crc >> 8])
-    packet = bytes([0xA5, 0, 0, 0, 0, 0x42]) + bytes([0] * 6) + modbus_frame_with_crc + bytes([0x15])
+    packet = (
+        bytes([0xA5, 0, 0, 0, 0, 0x42])
+        + bytes([0] * 6)
+        + modbus_frame_with_crc
+        + bytes([0x15])
+    )
 
     # Test with wrong expected length
     assert not ss.validate_packet(packet, 3)  # Expect 3 registers but only 2 in frame

--- a/src/tests/sunsynk/test_solarmansunsynk.py
+++ b/src/tests/sunsynk/test_solarmansunsynk.py
@@ -1,29 +1,98 @@
 """Solarman Sunsynk"""
 
+import logging
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sunsynk.solarmansunsynk import SolarmanSunsynk
+from sunsynk.solarmansunsynk import POLY, SolarmanSunsynk
 
-P_CONNECT = "sunsynk.solarmansunsynk.SolarmanSunsynk.connect"
+_LOGGER = logging.getLogger(__name__)
+
+
+def calculate_modbus_crc(frame: bytes) -> int:
+    """Calculate Modbus CRC for a frame."""
+    crc = 0xFFFF
+    for pos in range(len(frame)):
+        crc ^= frame[pos]
+        for _ in range(8):
+            if crc & 0x0001:
+                crc = (crc >> 1) ^ POLY
+            else:
+                crc >>= 1
+    return crc
 
 
 @pytest.mark.asyncio
-@patch(P_CONNECT, new_callable=AsyncMock)
-async def test_uss_sensor(connect: Any) -> None:
+@patch("sunsynk.solarmansunsynk.SolarmanSunsynk.connect")
+@patch("sunsynk.solarmansunsynk.SolarmanSunsynk.disconnect")
+async def test_uss_sensor(mock_disconnect: AsyncMock, mock_connect: AsyncMock) -> None:
     ss = SolarmanSunsynk(port="tcp://127.0.0.1:502", dongle_serial_number=101)
-    # await ss.connect()
-    ss.client = AsyncMock()
-    rhr = ss.client.read_holding_registers = AsyncMock()
 
-    # _LOGGER.warning("%s", dir(ss.client))
-    assert not rhr.called
-    await ss.read_holding_registers(1, 2)
-    assert rhr.called
+    # Create a mock client with the required methods
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
 
-    wrr = ss.client.write_multiple_holding_registers = AsyncMock()
-    assert not wrr.called
+    # Set up the client before any operations
+    ss.client = mock_client
+
+    # Test read_holding_registers
+    assert not mock_client.read_holding_registers.called
+
+    # The sequence number will be set by advance_sequence_number()
+    # We'll capture it when read_holding_registers is called
+    def read_holding_registers_side_effect(*args: tuple, **kwargs: dict[str, Any]) -> MagicMock:
+        sequence_number = kwargs.get('sequence_number', 0)
+        if not isinstance(sequence_number, int):
+            sequence_number = 0
+        # Create the Modbus frame first (without CRC)
+        modbus_frame = bytes([
+            1,                 # Slave ID
+            3,                 # Function code
+            4,                 # Data length
+            0, 1,             # First register
+            0, 2,             # Second register
+        ])
+        # Calculate CRC for the Modbus frame
+        crc = calculate_modbus_crc(modbus_frame)
+        # Create complete Modbus frame with CRC
+        modbus_frame_with_crc = modbus_frame + bytes([
+            crc & 0xFF,        # CRC low byte
+            crc >> 8,          # CRC high byte
+        ])
+
+        _LOGGER.debug("Modbus frame: %s", " ".join(f"{b:02x}" for b in modbus_frame))
+        _LOGGER.debug("Calculated CRC: %04x", crc)
+        _LOGGER.debug("Complete Modbus frame: %s", " ".join(f"{b:02x}" for b in modbus_frame_with_crc))
+
+        # Create complete response with V5 packet framing
+        mock_response.raw_response = bytes([
+            0xa5,             # Start byte
+            0x00,             # Ver
+            0x00,             # Slave address
+            0x00,             # Control code
+            0x00,             # Function code
+            sequence_number,  # Sequence number (now guaranteed to be an int)
+            0x00, 0x00,      # Data length
+            0x00, 0x00,      # Source address
+            0x00, 0x00,      # Destination address
+        ]) + modbus_frame_with_crc + bytes([
+            0x15              # End byte
+        ])
+
+        _LOGGER.debug("Complete V5 packet: %s", " ".join(f"{b:02x}" for b in mock_response.raw_response))
+
+        mock_response.registers = [1, 2]
+        return mock_response
+
+    mock_client.read_holding_registers.side_effect = read_holding_registers_side_effect
+
+    result = await ss.read_holding_registers(1, 2)
+    assert mock_client.read_holding_registers.called
+    assert result == [1, 2]
+
+    # Test write_register
+    assert not mock_client.write_multiple_holding_registers.called
     await ss.write_register(address=1, value=2)
-    assert wrr.called
+    assert mock_client.write_multiple_holding_registers.called


### PR DESCRIPTION
 Add sequence number management for packet validation in SolarmanSunsynk
 Add Modbus packet validation methods in SolarmanSunsynk
 Enhance Modbus frame handling in SolarmanSunsynk
 
- Introduced `current_sequence_number` attribute to track the sequence number.
- Added `advance_sequence_number` method to generate and increment the sequence number.
- Updated `write_register` and `read_holding_registers` methods to utilize the new sequence number for packet validation.
- Introduced `validate_modbus_crc` method to check the integrity of Modbus frames.
- Added `validate_packet` method to ensure received packets conform to expected structure and CRC.
- Updated `read_holding_registers` to validate response packets before returning registers.
- Defined a constant `POLY` for Modbus CRC polynomial.
- Updated the extraction of the Modbus frame to include the CRC byte for improved validation.
- Added detailed logging for extracted Modbus frames and calculated CRC values to aid in debugging.
- Introduced a new `calculate_modbus_crc` function in tests to ensure accurate CRC calculations for Modbus frames.
- Enhanced unit tests to validate the reading and writing of registers, ensuring proper interaction with the Modbus client.
    
Related PR & issues:
- https://github.com/kellerza/sunsynk/pull/391#issuecomment-2599665488
- https://github.com/kellerza/sunsynk/pull/391#issuecomment-2599698838
- https://github.com/kellerza/sunsynk/issues/398