### PR TITLE
Add UPS load-side power definitions

### DIFF
--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -101,6 +101,16 @@ SENSORS += (
     Sensor(673, "Gen L3 current", AMPS, -0.01),
 )
 
+####################
+# UPS / Backup Load Power
+####################
+SENSORS += (
+    Sensor16((640, 696), "UPS Load L1 power", WATT, 1),
+    Sensor16((641, 697), "UPS Load L2 power", WATT, 1),
+    Sensor16((642, 698), "UPS Load L3 power", WATT, 1),
+    Sensor16((643, 699), "UPS Load total power", WATT, 1),
+)
+
 ##############
 # Solar Power
 ##############


### PR DESCRIPTION
## Add UPS Load-side Power Definitions

### Overview
Adds support for UPS (Uninterruptible Power Supply) load-side power monitoring to three-phase inverters by introducing four new sensor definitions for comprehensive power tracking.

### Changes
- **New Sensor Definitions**: Added UPS load-side power sensors to `three_phase_common.py`
  - UPS Load L1 power (registers 640/696)
  - UPS Load L2 power (registers 641/697) 
  - UPS Load L3 power (registers 642/698)
  - UPS Load total power (registers 643/699)

- **Technical Implementation**: 
  - Uses `Sensor16` type to handle 32-bit values from combined low/high 16-bit word registers
  - Configured with `WATT` units and factor of `1` for proper power readings
  - Read-only sensors following existing patterns in the codebase

### Benefits
- Enables monitoring of UPS backup load power consumption per phase and total
- Provides visibility into power distribution during backup scenarios  
- Maintains consistency with existing three-phase power sensor patterns
- Supports comprehensive energy management and monitoring

### Testing
- [x] mypy type checking passes
- [x] Follows existing sensor definition patterns
- [x] Compatible with three-phase inverter systems

### Related Documentation
These sensors correspond to the UPS load-side power registers as specified in the inverter documentation:
- Registers 640-643: Low 16-bit words
- Registers 696-699: High 16-bit words