### PR TITLE
Add tested inverter Sunsynk 7kW (SYNK-7K-SG05LP1)

### DIFF
--- a/www/docs/guide/tested-inverters.md
+++ b/www/docs/guide/tested-inverters.md
@@ -13,5 +13,6 @@ There are several inverters that are rebranded Deye inverters, so you might have
 | Turbo-E 5kW        | DIY with JKBMS        | 0.1.4    | @agtconf      | BMS485 (top left)        |
 | Deye 16Kw SA Ver.  | S-Volt , Pace BMS     | beta/all | @deondti      | BMS485 and Solarman      |
 | Deye 25Kw 3PH HV   | Dyness HV4            | edge/dev | @proggaras   | BMS485                   |
+| Sunsynk 7kW        | Sunsynk W5.32         | multi    | @hamid-elaosta | RS485/CAN (top right)    |
 
 For details on how to wire these inverters, see [RS485 Wiring](./wiring).


### PR DESCRIPTION
Tested working on my SYNK-7K-SG05LP1 and 2x Sunsynk W5.32 batteries using a CAN/RS485 splitter in the port used by the BMS (top right) and a USR-W630.