### PR TITLE
Update the hass-addon-mbusd addon

### DIFF
--- a/hass-addon-mbusd/Dockerfile
+++ b/hass-addon-mbusd/Dockerfile
@@ -1,19 +1,19 @@
-ARG BUILD_FROM
-FROM ${BUILD_FROM}
+ARG BUILD_FROM=ghcr.io/home-assistant/aarch64-base
 
-RUN \
-    apk --no-cache add  --virtual .build-deps \
-        make cmake gcc g++ git pkgconf \
-    && git clone --depth 1 --branch v0.5.2 \
-        https://github.com/3cky/mbusd.git /usr/src \
-    && cd /usr/src \
-    && ls \
-    && cmake . \
-    && make \
-    && apk del .build-deps
-
+# mbusd Dockerfile as reference https://github.com/3cky/mbusd/blob/master/Dockerfile
+# - FROM home-assistant/base iso alpine:latest
+# - Clone a specific git tag from https://github.com/3cky/mbusd/releases
+FROM ${BUILD_FROM} AS build
+RUN apk add --no-cache alpine-sdk cmake linux-headers git
 WORKDIR /usr/src
+RUN git clone --depth 1 --branch v0.5.2 https://github.com/3cky/mbusd.git
+RUN cd mbusd \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr . \
+    && make && make install
 
+FROM ${BUILD_FROM} AS runtime
+COPY --from=build /usr/bin/mbusd /usr/bin/mbusd
+WORKDIR /usr/src
 COPY run.sh run.sh
 ENTRYPOINT [ "./run.sh" ]
 

--- a/hass-addon-mbusd/build.yaml
+++ b/hass-addon-mbusd/build.yaml
@@ -1,6 +1,7 @@
+# https://github.com/home-assistant/docker-base
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base"
-  armv7: "ghcr.io/home-assistant/armv7-base"
-  armhf: "ghcr.io/home-assistant/armhf-base"
-  amd64: "ghcr.io/home-assistant/amd64-base"
-  i386: "ghcr.io/home-assistant/i386-base"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
+  armv7: "ghcr.io/home-assistant/armv7-base:3.22"
+  armhf: "ghcr.io/home-assistant/armhf-base:3.22"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.22"
+  i386: "ghcr.io/home-assistant/i386-base:3.22"

--- a/hass-addon-mbusd/config.yaml
+++ b/hass-addon-mbusd/config.yaml
@@ -1,11 +1,12 @@
 name: Modbus TCP to Modbus RTU Gateway Add-on
 slug: hass-addon-mbusd
 description: Add-on for a Modbus TCP to Modbus RTU Gateway using mbusd
-version: "0.5.2"
+version: "0.5.2b"
 startup: services
 boot: auto
 url: 'https://kellerza.github.io/sunsynk/guide/mbusd'
 uart: true
+apparmor: true
 arch:
   - aarch64
   - amd64
@@ -16,7 +17,7 @@ ports:
   '502': 502
 ports_description:
   '502': Modbus
-host_network: true
+# host_network: true
 options:
   DEVICE: /dev/ttyUSB0
   BAUDRATE: 9600

--- a/hass-addon-mbusd/run.sh
+++ b/hass-addon-mbusd/run.sh
@@ -22,4 +22,4 @@ fi
 
 bashio::log.info "Starting mbusd -d -L - -v $LOGLEVEL -p $DEVICE -s $BAUDRATE -m $MODE -P 502"
 
-exec /usr/src/mbusd -d -L - -v $LOGLEVEL -p $DEVICE -s $BAUDRATE -m $MODE -P 502 -T $TIMEOUT
+exec /usr/bin/mbusd -d -L - -v $LOGLEVEL -p $DEVICE -s $BAUDRATE -m $MODE -P 502 -T $TIMEOUT

--- a/scripts/copy2local.cmd
+++ b/scripts/copy2local.cmd
@@ -1,9 +1,17 @@
 @echo off
-CALL :copy2 hass-addon-sunsynk-multi,\\192.168.1.8\addons\hass-addon-sunsynk-multi\
+@rem CALL :copy_ss hass-addon-sunsynk-multi,\\192.168.1.8\addons\hass-addon-sunsynk-multi
+CALL :copy_addon hass-addon-mbusd,\\192.168.1.8\addons\hass-addon-mbusd
 
 EXIT /B %ERRORLEVEL%
 
-:copy2
+:copy_ss
+
+echo # Copy sunsynk package
+for %%f in (pyproject.toml,MANIFEST.in,LICENSE,README.md,uv.lock) do xcopy /Y "%%f" %~2\sunsynk\
+xcopy /Y /S /EXCLUDE:scripts\copyexclude.txt src %~2\sunsynk\src\
+
+
+:copy_addon
 echo # Modify Config for local testing
 set cf=%~1\config.localtest.yaml
 cp %~1\config.yaml %cf%
@@ -13,9 +21,5 @@ xcopy /Y %cf% %~2\config.yaml
 
 echo # Copy '%~1' to '%~2'
 xcopy /Y /S /EXCLUDE:scripts\copyexclude.txt %~1 %~2
-
-echo # Copy sunsynk package
-for %%f in (pyproject.toml,MANIFEST.in,LICENSE,README.md,uv.lock) do xcopy /Y "%%f" %~2\sunsynk\
-xcopy /Y /S /EXCLUDE:scripts\copyexclude.txt src %~2\sunsynk\src\
 
 EXIT /B 0


### PR DESCRIPTION
This pull request refactors the build process for the `hass-addon-mbusd` add-on, updates configuration files, and improves local development scripts.

- Refactored the `Dockerfile` to use a multi-stage build, separating build and runtime environments for better security and efficiency. The build stage compiles `mbusd`, and only the necessary binary is copied to the runtime image.
- Updated base images in `build.yaml` to use explicit version tags (`3.22`) for all supported architectures, improving build reproducibility and stability.

Fixes #535 