### PR TITLE
Reject holding-register responses with an unexpected register count

### DIFF
--- a/src/sunsynk/sunsynk.py
+++ b/src/sunsynk/sunsynk.py
@@ -116,11 +116,17 @@ class Sunsynk:
                 )
                 continue
 
+            if len(r_r) != glen:
+                errs.append(
+                    OSError(
+                        f"response length mismatch reading {glen} registers from "
+                        f"{grp[0]}: got {len(r_r)}"
+                    )
+                )
+                continue
+
             regs = register_map(grp[0], r_r)
             new_regs.update(regs)
-
-            if len(r_r) != glen:
-                _LOG.warning("Did not complete read, only read %s/%s", len(r_r), glen)
 
             _LOG.debug(
                 "Request registers: %s glen=%d. Response %s len=%d. regs=%s",

--- a/src/tests/sunsynk/test_sunsynk.py
+++ b/src/tests/sunsynk/test_sunsynk.py
@@ -137,3 +137,34 @@ async def test_ss_read_sensors(rhr: MagicMock, state: InverterState) -> None:
     with pytest.raises(ExceptionGroup) as excinfo:
         await ss.read_sensors(sensors)
     assert len(excinfo.value.exceptions) == 2
+
+
+@pytest.mark.parametrize("response", ([9], [9, 8, 7]))
+@patch("sunsynk.Sunsynk.read_holding_registers")
+async def test_ss_rejects_response_length_mismatch(
+    rhr: MagicMock,
+    response: list[int],
+    state: InverterState,
+) -> None:
+    """A malformed response must not mix new words with cached registers."""
+    ss = Sunsynk()
+    ss.state = state
+    single = Sensor(1, "Single")
+    pair = Sensor((10, 11), "Pair")
+    state.track(single, pair)
+    state.update({10: 0, 11: 7})
+
+    def rhr_side_effect(start: int, length: int) -> Sequence[int]:
+        return [5] if (start, length) == (1, 1) else response
+
+    rhr.side_effect = rhr_side_effect
+    with pytest.raises(ExceptionGroup) as excinfo:
+        await ss.read_sensors([single, pair])
+
+    assert len(excinfo.value.exceptions) == 1
+    assert str(excinfo.value.exceptions[0]) == (
+        f"response length mismatch reading 2 registers from 10: got {len(response)}"
+    )
+    assert state[single] == 5
+    assert state[pair] == 7 << 16
+    assert state.registers == {1: 5, 10: 0, 11: 7}


### PR DESCRIPTION
## Problem

A Modbus function 03 response must contain exactly the number of registers requested. The response byte count is defined as `2 × N`, where `N` is the requested register quantity.

`Sunsynk.read_sensors()` currently detects a response-length mismatch but only logs a warning. It still maps the returned registers and applies them to the inverter state.

This is unsafe for multi-register sensors. When a response is truncated, `InverterState.update()` can combine the newly received word with a cached word from an earlier transaction, producing a valid-looking but incorrect value.

For example, if registers `(10, 11)` previously contain `(0, 7)` and a later two-register request returns only `[9]`, the resulting value is decoded from `(9, 7)`. The value therefore represents neither the previous state nor a complete new sample.

An oversized response can similarly place registers outside the requested range into the cache.

## Change

Reject responses whose register count differs from the requested count before calling `register_map()`.

The malformed register group is reported through the existing `ExceptionGroup` path and does not modify cached state. Successful independent register groups from the same polling cycle are still applied.

## Tests

Added regression coverage for:

- A truncated response: one register returned for a two-register request.
- An oversized response: three registers returned for a two-register request.
- Preserving the cached value of the rejected register group.
- Applying a successful independent register group from the same polling cycle.

## Verification

- 93 tests passed, 1 skipped.
- Optional `modbus-rs` test passed.
- Ruff, formatting, and Zuban checks passed.