### PR TITLE
Support for SUN-10K-SG05LP3-EU-SM2

### DIFF
--- a/src/sunsynk/definitions/__init__.py
+++ b/src/sunsynk/definitions/__init__.py
@@ -33,6 +33,7 @@ COMMON += (
             6: "High-voltage three-phase hybrid",  # Three-Phase High-Voltage Energy Storage Unit
             0x200: "Single-phase LV hybrid (3x MTTP)",
             0x103: "Single-phase hybrid",  # SUN-6K-OG01LP1-EU-AM2
+            0x500: "Low-voltage three-phase hybrid 10kW", # SUN-10K-SG05LP3-EU-SM2
             0x601: "High-voltage three-phase hybrid 6-15kW",
             0x602: "High-voltage three-phase hybrid 20-50kW",
         },


### PR DESCRIPTION
Hi,

I'm fresh owner of SUN-10K-SG05LP3-EU-SM2. Yesterday I connect RS485 and start playing with it. I noticed in log that line

`[05:35:13] WARNING device_type: Unknown register value 1280. Consider extending the definition with a PR. https://github.com/kellerza/sunsynk/tree/main/src/sunsynk/definitions`

So here is my PR.

Last thing, I've name this PR as support for this device. One thing which left is fix for SOC Battery temperature. It seems that it is working without any offset. I don't know full history of add-on so I'm open to how to do it in correct way. So far I've done it by overwritten sensor by custom sensor, but I think that this could be useful for other users.
