### PR TITLE
Offer time values across midnight

### DIFF
--- a/src/sunsynk/rwsensors.py
+++ b/src/sunsynk/rwsensors.py
@@ -231,17 +231,20 @@ class TimeRWSensor(RWSensor):
 
     def available_values(self, step_minutes: int, state: InverterState) -> list[str]:
         """Get the available values for this sensor."""
-        day = list(range(0, 24 * 60, step_minutes))
+        day = list(range(0, 48 * 60, step_minutes))
         minv = SSTime(strv=str(state.get(self.min, "0:00"))).minutes if self.min else 0
         maxv = SSTime(strv=str(state.get(self.max, "0:00"))).minutes if self.max else 0
-        if minv >= maxv:
+        wraps_midnight = minv >= maxv
+        if wraps_midnight:
             maxv += 24 * 60
         opt = [minv, *[v for v in day if (v > minv and v < maxv)], maxv]
         val = SSTime(strv=str(state.get(self, "0:00"))).minutes
+        if wraps_midnight and val < minv:
+            val += 24 * 60
         if val not in opt:
             opt.append(val)
         opt.sort()
-        return [SSTime(minutes=m).str_value for m in opt]
+        return list(dict.fromkeys(SSTime(minutes=m).str_value for m in opt))
 
     @property
     def dependencies(self) -> list[Sensor]:

--- a/src/tests/sunsynk/test_rwsensors.py
+++ b/src/tests/sunsynk/test_rwsensors.py
@@ -249,6 +249,21 @@ def test_time_rw(state: InverterState) -> None:
     assert s.available_values(15, state) == ["2:03", "2:10", "2:15", "2:22"]
 
 
+def test_time_rw_wrap_over_midnight() -> None:
+    """A time sensor whose window wraps past midnight offers the wrapped slots."""
+    state = InverterState()
+    sensor = TimeRWSensor(60, "prog1", factor=0.1)
+    sensor.min = TimeRWSensor(50, "prog6", factor=0.1)
+    sensor.max = TimeRWSensor(70, "prog2", factor=0.1)
+    state.track(sensor, sensor.min, sensor.max)
+    state.update({50: 2300, 60: 100, 70: 500})
+
+    values = sensor.available_values(60, state)
+
+    assert values == ["23:00", "0:00", "1:00", "2:00", "3:00", "4:00", "5:00"]
+    assert len(values) == len(set(values))
+
+
 # def test_update_sensor(caplog) -> None:
 #     s = NumberRWSensor(60, "two", factor=0.1)
 #     assert s.value is None


### PR DESCRIPTION
## Summary

- Extend time candidates to 48 hours when a configured window crosses midnight.
- Keep the current value in the wrapped interval and remove duplicate rendered times.
- Add a regression test for a 23:00 to 05:00 window.

Closes #667

## Testing

- `pytest src/tests/sunsynk` (71 passed)
- `pytest src/tests/sunsynk/test_rwsensors.py` (10 passed)
- `ruff check src/sunsynk/rwsensors.py src/tests/sunsynk/test_rwsensors.py`
- `ruff format --check src/sunsynk/rwsensors.py src/tests/sunsynk/test_rwsensors.py`